### PR TITLE
SetDress Publishing 的實現 (還在進行中)

### DIFF
--- a/plugins/global/publish/extract_source_fingerprint.py
+++ b/plugins/global/publish/extract_source_fingerprint.py
@@ -23,5 +23,5 @@ class ExtractSourceFingerprint(pyblish.api.ContextPlugin):
 
         context.data["sourceFingerprint"] = {
             "currentMaking": current_making,
-            "currentHash": hasher.hash(),
+            "currentHash": hasher.digest(),
         }

--- a/plugins/maya/create/create_setdress.py
+++ b/plugins/maya/create/create_setdress.py
@@ -1,0 +1,11 @@
+
+import avalon.maya
+
+
+class SetDressCreator(avalon.maya.Creator):
+    """A grouped package of loaded content"""
+
+    name = "setdressDefault"
+    label = "Set Dress"
+    family = "reveries.setdress"
+    icon = "tree"

--- a/plugins/maya/load/load_camera.py
+++ b/plugins/maya/load/load_camera.py
@@ -45,5 +45,7 @@ class CameraLoader(ReferenceLoader, avalon.api.Loader):
         self.interface = cmds.listRelatives(cmds.ls(nodes, type="camera"),
                                             parent=True)
 
+        return group_name
+
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_mayaShare.py
+++ b/plugins/maya/load/load_mayaShare.py
@@ -38,5 +38,7 @@ class MayaShareLoader(ReferenceLoader, avalon.api.Loader):
 
         self[:] = nodes
 
+        return group_name
+
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_model.py
+++ b/plugins/maya/load/load_model.py
@@ -30,17 +30,21 @@ class ModelLoader(ReferenceLoader, avalon.api.Loader):
 
         entry_path = self.file_path(representation["data"]["entry_fname"])
 
+        group_name = "{}:{}".format(namespace, name)
+
         with maya.maintained_selection():
             nodes = cmds.file(entry_path,
                               namespace=namespace,
                               reference=True,
                               returnNewNodes=True,
                               groupReference=True,
-                              groupName="{}:{}".format(namespace, name))
+                              groupName=group_name)
         self[:] = nodes
 
         transforms = cmds.ls(nodes, type="transform", long=True)
         self.interface = get_highest_in_hierarchy(transforms)
+
+        return group_name
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_pointcache.py
+++ b/plugins/maya/load/load_pointcache.py
@@ -52,6 +52,8 @@ class PointCacheReferenceLoader(ReferenceLoader, avalon.api.Loader):
         transforms = cmds.ls(nodes, type="transform", long=True)
         self.interface = get_highest_in_hierarchy(transforms)
 
+        return group_name
+
     def switch(self, container, representation):
         self.update(container, representation)
 
@@ -92,6 +94,8 @@ class PointCacheImportLoader(ImportLoader, avalon.api.Loader):
 
         reveries.maya.lib.lock_transform(group_name)
         self[:] = nodes
+
+        return group_name
 
     def update(self, container, representation):
         import maya.cmds as cmds

--- a/plugins/maya/load/load_rig.py
+++ b/plugins/maya/load/load_rig.py
@@ -33,12 +33,14 @@ class RigLoader(ReferenceLoader, avalon.api.Loader):
 
         entry_path = self.file_path(representation["data"]["entry_fname"])
 
+        group_name = "{}:{}".format(namespace, name)
+
         nodes = cmds.file(entry_path,
                           namespace=namespace,
                           reference=True,
                           returnNewNodes=True,
                           groupReference=True,
-                          groupName="{}:{}".format(namespace, name))
+                          groupName=group_name)
 
         self[:] = nodes
 
@@ -46,6 +48,8 @@ class RigLoader(ReferenceLoader, avalon.api.Loader):
         root = get_highest_in_hierarchy(transforms)
         sets = cmds.ls(nodes, type="objectSet")
         self.interface = root + sets
+
+        return group_name
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_sets.py
+++ b/plugins/maya/load/load_sets.py
@@ -40,4 +40,36 @@ class SetsLoader(avalon.api.Loader):
 
         container = loader.load(context, name, namespace, options)
 
+        self._place_set(container)
+
         return container
+
+    def _place_set(self, container):
+        from maya import cmds
+        from reveries.maya.plugins import parse_group_from_container
+
+        group = parse_group_from_container(container)
+        location = self._camera_coi()
+
+        if location is not None:
+            for attr, value in zip((".tx", ".ty", ".tz"), location):
+                cmds.setAttr(group + attr, value)
+
+        cmds.select(group)
+
+    def _camera_coi(self):
+        import math
+        from maya import cmds
+        from reveries.maya.lib import parse_active_camera
+
+        try:
+            camera = parse_active_camera()
+        except RuntimeError:
+            return None
+
+        COI = cmds.camera(camera, query=True, worldCenterOfInterest=True)
+
+        if any(math.isnan(val) for val in COI):
+            return None
+
+        return COI

--- a/plugins/maya/load/load_sets.py
+++ b/plugins/maya/load/load_sets.py
@@ -19,6 +19,7 @@ class SetsLoader(avalon.api.Loader):
 
     representations = [
         "mayaBinary",
+        "GPUCache",
         "Alembic",
         "SetDress",
     ]

--- a/plugins/maya/load/load_sets.py
+++ b/plugins/maya/load/load_sets.py
@@ -29,7 +29,6 @@ class SetsLoader(avalon.api.Loader):
         import avalon.api
         import avalon.maya
         from reveries.maya.plugins import ReferenceLoader
-        from maya import cmds
 
         representation = context["representation"]
 
@@ -40,55 +39,6 @@ class SetsLoader(avalon.api.Loader):
         Loader = next(L for L in Loaders if issubclass(L, ReferenceLoader))
         loader = Loader(context)
 
-        asset = context['asset']
-        namespace = namespace or avalon.maya.lib.unique_namespace(
-            asset["name"] + "_",
-            prefix="_" if asset["name"][0].isdigit() else "",
-            suffix="_",
-        )
-
-        options.update({"post_process": False, "useSelection": True})
         container = loader.load(context, name, namespace, options)
 
-        cmds.addAttr(container, longName="sourceLoader", dataType="string")
-
-        cmds.setAttr(container + ".sourceLoader",
-                     cmds.getAttr(container + ".loader"),
-                     type="string")
-        cmds.setAttr(container + ".loader",
-                     self.__class__.__name__,
-                     type="string")
-
         return container
-
-    def _get_source_loader(self, container):
-
-        import avalon.api
-
-        for Loader in avalon.api.discover(avalon.api.Loader):
-            if Loader.__name__ == container["sourceLoader"]:
-                return Loader
-
-    def update(self, container, representation):
-
-        import avalon.pipeline
-
-        Loader = self._get_source_loader(container)
-        context = avalon.pipeline.get_representation_context(representation)
-        loader = Loader(context)
-
-        return loader.update(container, representation)
-
-    def switch(self, container, representation):
-        self.update(container, representation)
-
-    def remove(self, container):
-
-        import avalon.pipeline
-
-        Loader = self._get_source_loader(container)
-        representation = container["representation"]
-        context = avalon.pipeline.get_representation_context(representation)
-        loader = Loader(context)
-
-        return loader.remove(container)

--- a/plugins/maya/load/load_sets.py
+++ b/plugins/maya/load/load_sets.py
@@ -19,7 +19,6 @@ class SetsLoader(avalon.api.Loader):
 
     representations = [
         "mayaBinary",
-        "GPUCache",
         "Alembic",
         "SetDress",
     ]

--- a/plugins/maya/publish/collect_container_interface.py
+++ b/plugins/maya/publish/collect_container_interface.py
@@ -1,0 +1,31 @@
+
+import pyblish.api
+from maya import cmds
+
+
+class CollectContainerInterface(pyblish.api.InstancePlugin):
+    """Collect container interfaces from instance
+
+    Collected data:
+
+        * interfaces
+
+    """
+
+    order = pyblish.api.CollectorOrder - 0.1
+    hosts = ["maya"]
+    label = "Container Interface"
+
+    CONTAINER_INTERFACE_ID = "pyblish.avalon.interface"
+
+    def process(self, instance):
+        instance.data["interfaces"] = list()
+
+        for node in instance:
+            try:
+                _id = cmds.getAttr(node + ".id")
+            except ValueError:
+                pass
+            else:
+                if _id == self.CONTAINER_INTERFACE_ID:
+                    instance.data["interfaces"].append(node)

--- a/plugins/maya/publish/collect_container_interface.py
+++ b/plugins/maya/publish/collect_container_interface.py
@@ -2,6 +2,8 @@
 import pyblish.api
 from maya import cmds
 
+from reveries.maya.plugins import AVALON_CONTAINER_INTERFACE_ID
+
 
 class CollectContainerInterface(pyblish.api.InstancePlugin):
     """Collect container interfaces from instance
@@ -16,8 +18,6 @@ class CollectContainerInterface(pyblish.api.InstancePlugin):
     hosts = ["maya"]
     label = "Container Interface"
 
-    CONTAINER_INTERFACE_ID = "pyblish.avalon.interface"
-
     def process(self, instance):
         instance.data["interfaces"] = list()
 
@@ -27,5 +27,5 @@ class CollectContainerInterface(pyblish.api.InstancePlugin):
             except ValueError:
                 pass
             else:
-                if _id == self.CONTAINER_INTERFACE_ID:
+                if _id == AVALON_CONTAINER_INTERFACE_ID:
                     instance.data["interfaces"].append(node)

--- a/plugins/maya/publish/collect_hierarchy.py
+++ b/plugins/maya/publish/collect_hierarchy.py
@@ -13,14 +13,8 @@ class CollectHierarchy(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         # Collect set members from container interface
-        for node in instance:
-            try:
-                _id = cmds.getAttr(node + ".id")
-            except ValueError:
-                pass
-            else:
-                if _id == "pyblish.avalon.interface":
-                    instance += cmds.ls(cmds.sets(node, query=True), long=True)
+        for node in instance.data["interfaces"]:
+            instance += cmds.ls(cmds.sets(node, query=True), long=True)
 
         # Collect all descendents
         instance += cmds.listRelatives(instance,

--- a/plugins/maya/publish/collect_hierarchy.py
+++ b/plugins/maya/publish/collect_hierarchy.py
@@ -11,6 +11,20 @@ class CollectHierarchy(pyblish.api.InstancePlugin):
     label = "Collect Hierarchy"
 
     def process(self, instance):
+
+        # Collect set members from container interface
+        for node in instance:
+            try:
+                _id = cmds.getAttr(node + ".id")
+            except ValueError:
+                pass
+            else:
+                if _id == "pyblish.avalon.interface":
+                    instance += cmds.ls(cmds.sets(node, query=True), long=True)
+
+        # Collect all descendents
         instance += cmds.listRelatives(instance,
                                        allDescendents=True,
                                        fullPath=True) or []
+
+        instance[:] = sorted(list(set(instance[:])))

--- a/plugins/maya/publish/collect_setdress.py
+++ b/plugins/maya/publish/collect_setdress.py
@@ -1,0 +1,31 @@
+
+import pyblish.api
+from reveries.maya.plugins import parse_group_from_interface
+
+
+class CollectSetDress(pyblish.api.InstancePlugin):
+    """Collect avalon sets
+    """
+
+    order = pyblish.api.CollectorOrder + 0.2
+    hosts = ["maya"]
+    label = "Collect SetDress"
+    families = ["reveries.setdress"]
+
+    def process(self, instance):
+
+        all_roots = dict()
+
+        for interface in instance.data["interfaces"]:
+            try:
+                root = parse_group_from_interface(interface)
+            except RuntimeError:
+                root = None
+
+            all_roots[str(interface)] = root
+
+        for intf, root in all_roots.items():
+            self.log.debug(intf)
+            self.log.debug(">>  " + root)
+
+        instance.data["setdressRoots"] = all_roots

--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -56,7 +56,7 @@ class ExtractModel(PackageExtractor):
             hasher.update_normals()
             hasher.update_uvmap()
 
-        self.add_data({"meshHash": hasher.hash()})
+        self.add_data({"meshHash": hasher.digest()})
 
         # Perform extraction
         self.log.info("Extracting %s" % str(self.member))

--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -6,7 +6,7 @@ import pyblish.api
 import maya.cmds as cmds
 import avalon.maya as maya
 
-from reveries.maya import capsule, io
+from reveries.maya import capsule, io, utils
 from reveries.plugins import PackageExtractor
 
 
@@ -30,14 +30,11 @@ class ExtractModel(PackageExtractor):
     ]
 
     def extract(self):
-        mesh_nodes = cmds.ls(self.member, type='mesh', ni=True, long=True)
-        clay_shader = "initialShadingGroup"
 
         with contextlib.nested(
             capsule.no_undo(),
             capsule.no_display_layers(self.member),
             capsule.no_smooth_preview(),
-            capsule.assign_shader(mesh_nodes, shadingEngine=clay_shader),
             maya.maintained_selection(),
             maya.without_extension(),
         ):
@@ -48,24 +45,37 @@ class ExtractModel(PackageExtractor):
         package_path = self.create_package(entry_file)
         entry_path = os.path.join(package_path, entry_file)
 
+        mesh_nodes = cmds.ls(self.member, type="mesh", ni=True, long=True)
+        clay_shader = "initialShadingGroup"
+
+        # Hash model
+        hasher = utils.MeshHasher()
+        for mesh in mesh_nodes:
+            hasher.add_mesh(mesh)
+        hash_val = hasher.hash()
+
+        self.add_data({"meshHash": hash_val})
+
         # Perform extraction
         self.log.info("Extracting %s" % str(self.member))
         cmds.select(self.member, noExpand=True)
-        cmds.file(
-            entry_path,
-            force=True,
-            typ="mayaBinary",
-            exportSelected=True,
-            preserveReferences=False,
-            # Shader assignment is the responsibility of
-            # riggers, for animators, and lookdev, for
-            # rendering.
-            shader=False,
-            # Construction history inherited from collection
-            # This enables a selective export of nodes
-            # relevant to this particular plug-in.
-            constructionHistory=False
-        )
+
+        with capsule.assign_shader(mesh_nodes, shadingEngine=clay_shader):
+            cmds.file(
+                entry_path,
+                force=True,
+                typ="mayaBinary",
+                exportSelected=True,
+                preserveReferences=False,
+                # Shader assignment is the responsibility of
+                # riggers, for animators, and lookdev, for
+                # rendering.
+                shader=False,
+                # Construction history inherited from collection
+                # This enables a selective export of nodes
+                # relevant to this particular plug-in.
+                constructionHistory=False
+            )
 
         self.log.info("Extracted {name} to {path}".format(
             name=self.data["subset"],

--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -51,10 +51,12 @@ class ExtractModel(PackageExtractor):
         # Hash model
         hasher = utils.MeshHasher()
         for mesh in mesh_nodes:
-            hasher.add_mesh(mesh)
-        hash_val = hasher.hash()
+            hasher.set_mesh(mesh)
+            hasher.update_points()
+            hasher.update_normals()
+            hasher.update_uvmap()
 
-        self.add_data({"meshHash": hash_val})
+        self.add_data({"meshHash": hasher.hash()})
 
         # Perform extraction
         self.log.info("Extracting %s" % str(self.member))

--- a/plugins/maya/publish/validate_camera_center_of_interest.py
+++ b/plugins/maya/publish/validate_camera_center_of_interest.py
@@ -1,0 +1,27 @@
+
+import math
+import pyblish.api
+from maya import cmds
+
+
+class ValidateCameraCenterOfInterest(pyblish.api.InstancePlugin):
+    """Ensure camera's `centerOfInterest` is not NaN
+    """
+
+    order = pyblish.api.ValidatorOrder + 0.1
+    hosts = ["maya"]
+    label = "Center Of Interest"
+    families = [
+        "reveries.camera",
+        "reveries.playblast",
+    ]
+
+    def process(self, instance):
+        try:
+            camera = cmds.ls(instance[:], type="camera")[0]
+        except IndexError:
+            raise Exception("No camera.")
+
+        coi_value = cmds.getAttr(camera + ".centerOfInterest")
+
+        assert not math.isnan(coi_value), ("Camera `centerOfInterest` is NaN.")

--- a/plugins/maya/publish/validate_mesh_lamina_faces.py
+++ b/plugins/maya/publish/validate_mesh_lamina_faces.py
@@ -11,7 +11,7 @@ class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin):
 
     """
 
-    order = pyblish.api.ValidatorOrder
+    order = pyblish.api.ValidatorOrder + 0.15
     label = "Mesh Lamina Faces"
     hosts = ["maya"]
     families = ["reveries.model"]

--- a/plugins/maya/publish/validate_mesh_lamina_faces.py
+++ b/plugins/maya/publish/validate_mesh_lamina_faces.py
@@ -1,0 +1,40 @@
+
+import pyblish.api
+
+from reveries.maya.plugins import MayaSelectInvalidAction
+
+
+class ValidateMeshLaminaFaces(pyblish.api.InstancePlugin):
+    """Validate meshes don't have lamina faces.
+
+    Lamina faces share all of their edges.
+
+    """
+
+    order = pyblish.api.ValidatorOrder
+    label = "Mesh Lamina Faces"
+    hosts = ["maya"]
+    families = ["reveries.model"]
+    actions = [
+        pyblish.api.Category("Select"),
+        MayaSelectInvalidAction,
+    ]
+
+    @staticmethod
+    def get_invalid(instance):
+        from maya import cmds
+
+        meshes = cmds.ls(instance, type="mesh", long=True)
+        invalid = [mesh for mesh in meshes if
+                   cmds.polyInfo(mesh, laminaFaces=True)]
+
+        return invalid
+
+    def process(self, instance):
+        """Process all the nodes in the instance 'objectSet'"""
+
+        invalid = self.get_invalid(instance)
+
+        if invalid:
+            raise ValueError("Meshes found with lamina faces: "
+                             "{0}".format(invalid))

--- a/plugins/maya/publish/validate_setdress_roots.py
+++ b/plugins/maya/publish/validate_setdress_roots.py
@@ -1,0 +1,18 @@
+
+import pyblish.api
+
+
+class ValidateSetDressRoots(pyblish.api.InstancePlugin):
+    """Verify setdress has root transform"""
+
+    order = pyblish.api.ValidatorOrder
+    hosts = ["maya"]
+    label = "Validate SetDress Roots"
+    families = ["reveries.setdress"]
+
+    def process(self, instance):
+
+        for intf, root in instance.data["setdressRoots"].items():
+            if not root:
+                raise Exception("Interface {!r} has no transform nodes, "
+                                "this is a bug.".format(str(intf)))

--- a/plugins/maya/publish/validate_setdress_transforms.py
+++ b/plugins/maya/publish/validate_setdress_transforms.py
@@ -1,0 +1,105 @@
+
+import pyblish.api
+
+from maya import cmds
+
+from reveries.plugins import RepairInstanceAction
+from reveries.maya.plugins import MayaSelectInvalidAction
+import reveries.lib as lib
+
+
+class RepairInvalid(RepairInstanceAction):
+
+    label = "Reset Illegal Transforms"
+
+
+class ValidateSetDressModelTransforms(pyblish.api.InstancePlugin):
+    """Verify only root nodes of the loaded asset have transformations.
+
+    Note: This check is temporary and is subject to change.
+
+    Example outliner:
+    <> means referenced
+    ===================================================================
+
+    setdress_GRP|
+        props_GRP|
+            barrel_01_:modelDefault|        [can have transforms]
+                <> barrel_01_:barrel_GRP    [CAN'T have transforms]
+
+            fence_01_:modelDefault|         [can have transforms]
+                <> fence_01_:fence_GRP      [CAN'T have transforms]
+
+    """
+
+    order = pyblish.api.ValidatorOrder + 0.1
+    label = "Setdress Transforms"
+    families = ["reveries.setdress"]
+    actions = [
+        pyblish.api.Category("Select"),
+        MayaSelectInvalidAction,
+        pyblish.api.Category("Fix It"),
+        RepairInvalid,
+    ]
+
+    prompt_message = ("You are about to reset the matrix to the default "
+                      "values. This can alter the look of your scene. "
+                      "Are you sure you want to continue?")
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError("Found {} invalid transforms of setdress "
+                               "items".format(len(invalid)))
+
+    @staticmethod
+    def get_invalid(instance):
+
+        container_roots = list(instance.data["setdressRoots"].values())
+
+        transforms_in_container = cmds.listRelatives(container_roots,
+                                                     allDescendents=True,
+                                                     type="transform",
+                                                     fullPath=True)
+
+        # Ensure all are identity matrix
+        invalid = []
+        for transform in transforms_in_container:
+            node_matrix = cmds.xform(transform,
+                                     query=True,
+                                     matrix=True,
+                                     objectSpace=True)
+            if not lib.matrix_equals(node_matrix, lib.DEFAULT_MATRIX):
+                invalid.append(transform)
+
+        return invalid
+
+    @classmethod
+    def fix(cls, instance):
+        """Reset matrix for illegally transformed nodes
+
+        We want to ensure the user knows the reset will alter the look of
+        the current scene because the transformations were done on asset
+        nodes instead of the asset top node.
+
+        Args:
+            instance:
+
+        Returns:
+            None
+
+        """
+        from reveries.plugins import message_box_warning
+
+        # Store namespace in variable, cosmetics thingy
+        choice = message_box_warning(title="Matrix reset",
+                                     message=cls.prompt_message,
+                                     optional=True)
+
+        invalid = cls.get_invalid(instance)
+        if not invalid:
+            cls.log.info("No invalid nodes")
+            return
+
+        if choice:
+            cmds.xform(invalid, matrix=lib.DEFAULT_MATRIX, objectSpace=True)

--- a/plugins/maya/publish/validate_transform_freezed.py
+++ b/plugins/maya/publish/validate_transform_freezed.py
@@ -2,7 +2,7 @@
 import pyblish.api
 from maya import cmds
 
-from reveries import math
+from reveries import lib
 from reveries.maya.plugins import MayaSelectInvalidAction
 
 
@@ -60,7 +60,7 @@ class ValidateTranformFreezed(pyblish.api.InstancePlugin):
                                 matrix=True,
                                 objectSpace=True)
 
-            if not math.matrix_equals(_identity, matrix, _tolerance):
+            if not lib.matrix_equals(_identity, matrix, _tolerance):
                 ignore = False
 
                 for shape in cmds.listRelatives(transform, shapes=True) or []:

--- a/reveries/lib.py
+++ b/reveries/lib.py
@@ -1,4 +1,11 @@
 
+
+DEFAULT_MATRIX = [1.0, 0.0, 0.0, 0.0,
+                  0.0, 1.0, 0.0, 0.0,
+                  0.0, 0.0, 1.0, 0.0,
+                  0.0, 0.0, 0.0, 1.0]
+
+
 def matrix_equals(a, b, tolerance=1e-10):
     """
     Compares two matrices with an imperfection tolerance

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -7,6 +7,7 @@ from maya.api import OpenMaya as om
 
 from .. import utils, lib
 from ..vendor.six import string_types
+from .vendor import capture
 
 
 log = logging.getLogger(__name__)
@@ -659,3 +660,19 @@ def get_highest_in_hierarchy(nodes):
             highest.append(node)
 
     return highest
+
+
+def parse_active_camera():
+    """Parse the active camera
+
+    Raises
+        RuntimeError: When no active modelPanel an error is raised.
+
+    Returns:
+        str: Name of camera
+
+    """
+    panel = capture.parse_active_panel()
+    camera = cmds.modelPanel(panel, query=True, camera=True)
+
+    return camera

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -429,7 +429,7 @@ def apply_shaders(relationships, namespace=None):
             # Find all meshes matching this particular ID
             # Convert IDs to mesh + id, e.g. "nameOfNode.f[1:100]"
             meshes = list(".".join([mesh, faces])
-                          for mesh in lsattr(AVALON_ID_ATTR_SHORT, value=mesh))
+                          for mesh in lsAttr(AVALON_ID_ATTR_SHORT, value=mesh))
 
             if not meshes:
                 continue
@@ -457,7 +457,7 @@ def hasAttr(node, attr):
     return cmds.objExists(node + "." + attr)
 
 
-def lsattr(attr, value=None):
+def lsAttr(attr, value=None):
     """Return nodes matching `key` and `value`
 
     Arguments:
@@ -466,29 +466,29 @@ def lsattr(attr, value=None):
             is provided, return all nodes with this attribute.
 
     Example:
-        >> lsattr("id", "myId")
+        >> lsAttr("id", "myId")
         ["myNode"]
-        >> lsattr("id")
+        >> lsAttr("id")
         ["myNode", "myOtherNode"]
 
     """
 
     if value is None:
         return cmds.ls("*.%s" % attr)
-    return lsattrs({attr: value})
+    return lsAttrs({attr: value})
 
 
-def lsattrs(attrs):
+def lsAttrs(attrs):
     """Return nodes with the given attribute(s).
 
     Arguments:
         attrs (dict): Name and value pairs of expected matches
 
     Example:
-        >> lsattr("age")  # Return nodes with attribute `age`
-        >> lsattr({"age": 5})  # Return nodes with an `age` of 5
+        >> lsAttr("age")  # Return nodes with attribute `age`
+        >> lsAttr({"age": 5})  # Return nodes with an `age` of 5
         >> # Return nodes with both `age` and `color` of 5 and blue
-        >> lsattr({"age": 5, "color": "blue"})
+        >> lsAttr({"age": 5, "color": "blue"})
 
     Returns a list.
 

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -16,11 +16,6 @@ log = logging.getLogger(__name__)
 AVALON_ID_ATTR_LONG = "AvalonID"
 AVALON_ID_ATTR_SHORT = "avid"
 
-DEFAULT_MATRIX = [1.0, 0.0, 0.0, 0.0,
-                  0.0, 1.0, 0.0, 0.0,
-                  0.0, 0.0, 1.0, 0.0,
-                  0.0, 0.0, 0.0, 1.0]
-
 TRANSFORM_ATTRS = [
     "translateX", "translateY", "translateZ",
     "rotateX", "rotateY", "rotateZ",

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -438,6 +438,25 @@ def apply_shaders(relationships, namespace=None):
             cmds.sets(meshes, forceElement=shader)
 
 
+def hasAttr(node, attr):
+    """Convenience function for determining if an object has an attribute
+
+    This function is simply using `cmds.objExists`, it's about 4 times faster
+    then `cmds.attributeQuery(attr, node=node, exists=True)`, and about 9 times
+    faster then pymel's `PyNode(node).hasAttr(attr)`.
+
+    Arguments:
+        node (str): Name of Maya node
+        attr (str): Name of Maya attribute
+
+    Example:
+        >> hasAttr("pCube1", "translateX")
+        True
+
+    """
+    return cmds.objExists(node + "." + attr)
+
+
 def lsattr(attr, value=None):
     """Return nodes matching `key` and `value`
 

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -676,3 +676,24 @@ def parse_active_camera():
     camera = cmds.modelPanel(panel, query=True, camera=True)
 
     return camera
+
+
+def connect_message(source, target, attrname, lock=True):
+    """Connect nodes with message channel
+
+    This will build a convenience custom connection between two nodes:
+
+        source.message -> target.attrname
+
+    Args:
+        source (str): Message output node
+        target (str): Message input node
+        attrname (str): Name of input attribute of target node
+        lock (bool, optional): Lock attribute if set to True (default True)
+
+    """
+    cmds.addAttr(target, longName=attrname, attributeType="message")
+
+    target_attr = target + "." + attrname
+    cmds.connectAttr(source + ".message", target_attr)
+    cmds.setAttr(target_attr, lock=lock)

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -15,6 +15,7 @@ from ..plugins import (
 AVALON_PORTS = ":AVALON_PORTS"
 
 AVALON_VESSEL_ATTR = "vessel"
+AVALON_CONTAINER_ATTR = "container"
 
 
 REPRS_PLUGIN_MAPPING = {
@@ -143,7 +144,7 @@ class ReferenceLoader(PackageLoader):
                                  loader=self.__class__.__name__)
 
         connect_message(group_name, interface, AVALON_VESSEL_ATTR)
-        connect_message(interface, container, AVALON_VESSEL_ATTR)
+        connect_message(container, interface, AVALON_CONTAINER_ATTR)
 
         return container
 
@@ -287,7 +288,7 @@ class ImportLoader(PackageLoader):
                                  loader=self.__class__.__name__)
 
         connect_message(group_name, interface, AVALON_VESSEL_ATTR)
-        connect_message(interface, container, AVALON_VESSEL_ATTR)
+        connect_message(container, interface, AVALON_CONTAINER_ATTR)
 
         return container
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -93,6 +93,27 @@ def container_interfacing(name,
     return interface
 
 
+def read_interface_data(interface):
+    """Read data from interface node's custom attributes
+
+    Arguments:
+        interface (str): Name of interface node
+
+    Returns:
+        _id (str): representation id
+        data (dict): {name: str, namespace: str, loader: str}
+
+    """
+    import maya.cmds as cmds
+
+    _id = cmds.getAttr(interface + ".representation_id")
+    name = cmds.getAttr(interface + ".name")
+    namespace = cmds.getAttr(interface + ".namespace")
+    loader = cmds.getAttr(interface + ".loader")
+
+    return _id, dict(name=name, namespace=namespace, loader=loader)
+
+
 def parse_interface_from_container(container):
     """Return interface node of container
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -110,18 +110,16 @@ def parse_interface_from_container(container):
     return nodes[0]
 
 
-def parse_group_from_container(container):
-    """Return group node of container
+def parse_group_from_interface(interface):
+    """Return group node of interface
 
     Arguments:
-        container (str): Name of container node
+        interface (str): Name of interface node
 
     Returns a str
 
     """
     import maya.cmds as cmds
-
-    interface = parse_interface_from_container(container)
 
     group = cmds.listConnections(interface + "." + AVALON_VESSEL_ATTR,
                                  source=True,
@@ -131,6 +129,19 @@ def parse_group_from_container(container):
         raise RuntimeError("Can not get group node, this is a bug.")
 
     return group[0]
+
+
+def parse_group_from_container(container):
+    """Return group node of container
+
+    Arguments:
+        container (str): Name of container node
+
+    Returns a str
+
+    """
+    interface = parse_interface_from_container(container)
+    return parse_group_from_interface(interface)
 
 
 class ReferenceLoader(PackageLoader):

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -109,6 +109,29 @@ def parse_interface_from_container(container):
     return nodes[0]
 
 
+def parse_group_from_container(container):
+    """Return group node of container
+
+    Arguments:
+        container (str): Name of container node
+
+    Returns a str
+
+    """
+    import maya.cmds as cmds
+
+    interface = parse_interface_from_container(container)
+
+    group = cmds.listConnections(interface + "." + AVALON_VESSEL_ATTR,
+                                 source=True,
+                                 destination=False,
+                                 type="transform") or []
+    if not group:
+        raise RuntimeError("Can not get group node, this is a bug.")
+
+    return group[0]
+
+
 class ReferenceLoader(PackageLoader):
     """A basic ReferenceLoader for Maya
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -14,6 +14,8 @@ from ..plugins import (
 
 AVALON_PORTS = ":AVALON_PORTS"
 
+AVALON_VESSEL_ATTR = "vessel"
+
 
 REPRS_PLUGIN_MAPPING = {
     "Alembic": "AbcImport.mll",
@@ -107,6 +109,7 @@ class ReferenceLoader(PackageLoader):
     def load(self, context, name=None, namespace=None, options=None):
         from avalon.maya import lib
         from avalon.maya.pipeline import containerise
+        from reveries.maya.lib import connect_message
 
         load_plugin(context["representation"]["name"])
 
@@ -118,24 +121,31 @@ class ReferenceLoader(PackageLoader):
             suffix="_",
         )
 
-        self.process_reference(context=context,
-                               name=name,
-                               namespace=namespace,
-                               options=options)
+        group_name = self.process_reference(context=context,
+                                            name=name,
+                                            namespace=namespace,
+                                            options=options)
 
         # Only containerize if any nodes were loaded by the Loader
         nodes = self[:]
         if not nodes:
             return
 
-        container_interfacing(name, namespace, self.interface, context)
+        interface = container_interfacing(name,
+                                          namespace,
+                                          self.interface,
+                                          context)
 
-        return containerise(
-            name=name,
-            namespace=namespace,
-            nodes=nodes,
-            context=context,
-            loader=self.__class__.__name__)
+        container = containerise(name=name,
+                                 namespace=namespace,
+                                 nodes=nodes,
+                                 context=context,
+                                 loader=self.__class__.__name__)
+
+        connect_message(group_name, interface, AVALON_VESSEL_ATTR)
+        connect_message(interface, container, AVALON_VESSEL_ATTR)
+
+        return container
 
     def update(self, container, representation):
         from maya import cmds
@@ -243,6 +253,7 @@ class ImportLoader(PackageLoader):
     def load(self, context, name=None, namespace=None, options=None):
         from avalon.maya import lib
         from avalon.maya.pipeline import containerise
+        from reveries.maya.lib import connect_message
 
         load_plugin(context["representation"]["name"])
 
@@ -254,24 +265,31 @@ class ImportLoader(PackageLoader):
             suffix="_",
         )
 
-        self.process_import(context=context,
-                            name=name,
-                            namespace=namespace,
-                            options=options)
+        group_name = self.process_import(context=context,
+                                         name=name,
+                                         namespace=namespace,
+                                         options=options)
 
         # Only containerize if any nodes were loaded by the Loader
         nodes = self[:]
         if not nodes:
             return
 
-        container_interfacing(name, namespace, self.interface, context)
+        interface = container_interfacing(name,
+                                          namespace,
+                                          self.interface,
+                                          context)
 
-        return containerise(
-            name=name,
-            namespace=namespace,
-            nodes=nodes,
-            context=context,
-            loader=self.__class__.__name__)
+        container = containerise(name=name,
+                                 namespace=namespace,
+                                 nodes=nodes,
+                                 context=context,
+                                 loader=self.__class__.__name__)
+
+        connect_message(group_name, interface, AVALON_VESSEL_ATTR)
+        connect_message(interface, container, AVALON_VESSEL_ATTR)
+
+        return container
 
     def update(self, container, representation):
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -16,6 +16,7 @@ from ..plugins import (
 
 AVALON_PORTS = ":AVALON_PORTS"
 
+AVALON_CONTAINER_INTERFACE_ID = "pyblish.avalon.interface"
 AVALON_VESSEL_ATTR = "vessel"
 AVALON_CONTAINER_ATTR = "container"
 
@@ -65,7 +66,7 @@ def container_interfacing(name, namespace, nodes, context, suffix="PORT"):
     interface = cmds.sets(nodes, name="%s_%s_%s" % (namespace, name, suffix))
 
     data = OrderedDict()
-    data["id"] = "pyblish.avalon.interface"
+    data["id"] = AVALON_CONTAINER_INTERFACE_ID
     data["name"] = name
     data["namespace"] = namespace
     data["representation"] = str(context["representation"]["_id"])
@@ -98,7 +99,7 @@ def parse_interface_from_container(container):
     namespace = cmds.getAttr(container + ".namespace")
 
     nodes = lib.lsAttrs({
-        "id": "pyblish.avalon.interface",
+        "id": AVALON_CONTAINER_INTERFACE_ID,
         "representation": representation,
         "namespace": namespace})
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -63,7 +63,7 @@ def container_interfacing(name, namespace, nodes, context, suffix="PORT"):
     data["id"] = "pyblish.avalon.interface"
     data["name"] = name
     data["namespace"] = namespace
-    data["representation"] = context["representation"]["_id"]
+    data["representation"] = str(context["representation"]["_id"])
 
     avalon.maya.lib.imprint(interface, data)
 

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -93,25 +93,24 @@ def container_interfacing(name,
     return interface
 
 
-def read_interface_data(interface):
-    """Read data from interface node's custom attributes
+def read_interface_to_package(interface):
+    """Read attributes from interface node for package dumping
 
     Arguments:
         interface (str): Name of interface node
 
     Returns:
         _id (str): representation id
-        data (dict): {name: str, namespace: str, loader: str}
+        data (dict): {name: str, loader: str}
 
     """
     import maya.cmds as cmds
 
     _id = cmds.getAttr(interface + ".representation_id")
     name = cmds.getAttr(interface + ".name")
-    namespace = cmds.getAttr(interface + ".namespace")
     loader = cmds.getAttr(interface + ".loader")
 
-    return _id, dict(name=name, namespace=namespace, loader=loader)
+    return _id, dict(name=name, loader=loader)
 
 
 def parse_interface_from_container(container):

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -44,7 +44,12 @@ def load_plugin(representation):
         cmds.loadPlugin(plugin, quiet=True)
 
 
-def container_interfacing(name, namespace, nodes, context, suffix="PORT"):
+def container_interfacing(name,
+                          namespace,
+                          nodes,
+                          context,
+                          loader,
+                          suffix="PORT"):
     """Expose crucial `nodes` as an interface of a subset container
 
     Interfacing enables a faster way to access nodes of loaded subsets from
@@ -67,9 +72,13 @@ def container_interfacing(name, namespace, nodes, context, suffix="PORT"):
 
     data = OrderedDict()
     data["id"] = AVALON_CONTAINER_INTERFACE_ID
+    data["asset"] = context["asset"]["name"]
     data["name"] = name
     data["namespace"] = namespace
-    data["representation"] = str(context["representation"]["_id"])
+    data["version"] = context["version"]["name"]
+    data["representation"] = context["representation"]["name"]
+    data["representation_id"] = str(context["representation"]["_id"])
+    data["loader"] = loader
 
     avalon.maya.lib.imprint(interface, data)
 
@@ -100,7 +109,7 @@ def parse_interface_from_container(container):
 
     nodes = lib.lsAttrs({
         "id": AVALON_CONTAINER_INTERFACE_ID,
-        "representation": representation,
+        "representation_id": representation,
         "namespace": namespace})
 
     if not len(nodes) == 1:
@@ -195,10 +204,11 @@ class ReferenceLoader(PackageLoader):
         if not nodes:
             return
 
-        interface = container_interfacing(name,
-                                          namespace,
-                                          self.interface,
-                                          context)
+        interface = container_interfacing(name=name,
+                                          namespace=namespace,
+                                          nodes=self.interface,
+                                          context=context,
+                                          loader=self.__class__.__name__)
 
         container = containerise(name=name,
                                  namespace=namespace,
@@ -339,10 +349,11 @@ class ImportLoader(PackageLoader):
         if not nodes:
             return
 
-        interface = container_interfacing(name,
-                                          namespace,
-                                          self.interface,
-                                          context)
+        interface = container_interfacing(name=name,
+                                          namespace=namespace,
+                                          nodes=self.interface,
+                                          context=context,
+                                          loader=self.__class__.__name__)
 
         container = containerise(name=name,
                                  namespace=namespace,

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -5,6 +5,8 @@ from collections import OrderedDict
 import avalon.api
 import avalon.maya.lib
 
+from . import lib
+
 from ..plugins import (
     PackageLoader,
     message_box_error,
@@ -79,6 +81,32 @@ def container_interfacing(name, namespace, nodes, context, suffix="PORT"):
     cmds.sets(interface, addElement=main_interface)
 
     return interface
+
+
+def parse_interface_from_container(container):
+    """Return interface node of container
+
+    Arguments:
+        container (str): Name of container node
+
+    Returns a str
+
+    """
+    import maya.cmds as cmds
+
+    representation = cmds.getAttr(container + ".representation")
+    namespace = cmds.getAttr(container + ".namespace")
+
+    nodes = lib.lsAttrs({
+        "id": "pyblish.avalon.interface",
+        "representation": representation,
+        "namespace": namespace})
+
+    if not len(nodes) == 1:
+        raise RuntimeError("Container has none or more then one interface, "
+                           "this is a bug.")
+
+    return nodes[0]
 
 
 class ReferenceLoader(PackageLoader):

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -9,6 +9,8 @@ class MeshHasher(_C4Hasher):
     Based on Avalanche-io C4 Asset ID, hashing mesh geometry by ipnuting all
     vertices' position.
 
+    Vertex and mesh input order matters, transform does not.
+
     Usage:
         >> hasher = MeshHasher()
         >> hasher.add_mesh("path|to|mesh")
@@ -31,7 +33,7 @@ class MeshHasher(_C4Hasher):
     """
 
     def add_mesh(self, dag_path):
-        """Add one file to hasher
+        """Add one mesh geometry to hasher
 
         Arguments:
             dag_path (str): Mesh node's DAG path

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -1,0 +1,48 @@
+
+from maya.api import OpenMaya as om
+from ..utils import _C4Hasher
+
+
+class MeshHasher(_C4Hasher):
+    """A mesh geometry hasher for Maya
+
+    Based on Avalanche-io C4 Asset ID, hashing mesh geometry by ipnuting all
+    vertices' position.
+
+    Usage:
+        >> hasher = MeshHasher()
+        >> hasher.add_mesh("path|to|mesh")
+
+        You can keep adding more meshes.
+        And get the hash value by
+        >> hasher.hash()
+        'c463d2Wh5NyBMQRHyxbdBxCzZfaKXvBQaawgfgG18moxQU2jdmaSbCWL...'
+
+        You can still adding more meshes at this point
+        >> hasher.add_mesh("path|to|more|mesh")
+
+        And get the hash value of all meshes added so far
+        >> hasher.hash()
+        'c43cysVyTd7kYurvAa5ooR6miJJgUZ9QnBCHZeNK3en9aQ96KHsoJyJX...'
+
+        Until you call `clear`
+        >> hasher.clear()
+
+    """
+
+    def add_mesh(self, dag_path):
+        """Add one file to hasher
+
+        Arguments:
+            dag_path (str): Mesh node's DAG path
+
+        """
+        sel_list = om.MSelectionList()
+        sel_list.add(dag_path)
+
+        sel_obj = sel_list.getDagPath(0)
+        mesh = om.MFnMesh(sel_obj)
+
+        for vt in mesh.getPoints():
+            pos = "{},{},{}".format(*vt)
+            self.hash_obj.update(pos)

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -3,37 +3,71 @@ from maya.api import OpenMaya as om
 from ..utils import _C4Hasher
 
 
-class MeshHasher(_C4Hasher):
+def _hash_MPoint(x, y, z, w):
+    x = (x + 1) * 233
+    y = (y + x) * 239
+    z = (z + y) * 241
+    return (x + y + z) * w
+
+
+def _hash_MFloatVectors(x, y, z):
+    x = (x + 1) * 383
+    y = (y + x) * 389
+    z = (z + y) * 397
+    return x + y + z
+
+
+def _hash_UV(u, v):
+    u = (u + 1) * 547
+    v = (v + u) * 557
+    return u * v
+
+
+class MeshHasher(object):
     """A mesh geometry hasher for Maya
 
-    Based on Avalanche-io C4 Asset ID, hashing mesh geometry by ipnuting all
-    vertices' position.
+    For quickly identifying if any change on vertices, normals and UVs.
+    Hash value will be encoded as Avalanche-io C4 Asset ID.
 
-    Vertex and mesh input order matters, transform does not.
+    Order matters, transform does not.
 
-    Usage:
+    Example Usage:
         >> hasher = MeshHasher()
-        >> hasher.add_mesh("path|to|mesh")
-
-        You can keep adding more meshes.
-        And get the hash value by
+        >> hasher.set_mesh("path|to|mesh")
+        >> hasher.update_points()
+        >> hasher.update_normals()
+        >> hasher.update_uvmap()
         >> hasher.hash()
-        'c463d2Wh5NyBMQRHyxbdBxCzZfaKXvBQaawgfgG18moxQU2jdmaSbCWL...'
+        {'normals': 'c41MSCnAGqWS9dBDDpydbpcMwzzFkGH66jNpuTqctfY...',
+         'points': 'c44fV5wa6bNiekUadZ4HsRPDL2HZ11RFKcXhf3pntsUJ...',
+         'uvmap': 'c45JRQTPxgMNYfcijAbm31vkJRt6CUUSn7ew2X1Mnyjwi...'}
 
-        You can still adding more meshes at this point
-        >> hasher.add_mesh("path|to|more|mesh")
-
-        And get the hash value of all meshes added so far
+        Hash meshes in loop
+        >> for mesh in cmds.ls(type="mesh", ni=Ture, long=True)
+        ...    hasher.set_mesh(mesh)
+        ...    hasher.update_points()
+        ...    hasher.update_normals()
+        ...
         >> hasher.hash()
-        'c43cysVyTd7kYurvAa5ooR6miJJgUZ9QnBCHZeNK3en9aQ96KHsoJyJX...'
+        {'normals': 'c456rBNH5pzobqjHzFnHApanrTdJo64r2R8o4GJxqU9G...',
+         'points': 'c449wXhjNSSKfnUjPp2ub3fd1DeNowW2x5gBJDYrSvxrT...'}
 
-        Until you call `clear`
+        You can still adding more meshes until you call `clear`
         >> hasher.clear()
 
     """
 
-    def add_mesh(self, dag_path):
-        """Add one mesh geometry to hasher
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        self._mesh = None
+        self._points = 0
+        self._normals = 0
+        self._uvmap = 0
+
+    def set_mesh(self, dag_path):
+        """Set one mesh geometry node to hasher
 
         Arguments:
             dag_path (str): Mesh node's DAG path
@@ -41,10 +75,38 @@ class MeshHasher(_C4Hasher):
         """
         sel_list = om.MSelectionList()
         sel_list.add(dag_path)
-
         sel_obj = sel_list.getDagPath(0)
-        mesh = om.MFnMesh(sel_obj)
+        self._mesh = om.MFnMesh(sel_obj)
 
-        for vt in mesh.getPoints():
-            pos = "{},{},{}".format(*vt)
-            self.hash_obj.update(pos)
+    def update_points(self):
+        for i, vt in enumerate(self._mesh.getPoints()):
+            self._points += _hash_MPoint(*vt) + i
+
+    def update_normals(self):
+        for i, vt in enumerate(self._mesh.getNormals()):
+            self._normals += _hash_MFloatVectors(*vt) + i
+
+    def update_uvmap(self, uv_set=""):
+        for i, uv in enumerate(zip(*self._mesh.getUVs(uv_set))):
+            self._uvmap += _hash_UV(*uv) + i
+
+    def hash(self):
+        result = dict()
+        hasher = _C4Hasher()
+
+        if self._points:
+            hasher.hash_obj.update(str(self._points))
+            result["points"] = hasher.hash()
+            hasher.clear()
+
+        if self._normals:
+            hasher.hash_obj.update(str(self._normals))
+            result["normals"] = hasher.hash()
+            hasher.clear()
+
+        if self._uvmap:
+            hasher.hash_obj.update(str(self._uvmap))
+            result["uvmap"] = hasher.hash()
+            hasher.clear()
+
+        return result

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -37,7 +37,7 @@ class MeshHasher(object):
         >> hasher.update_points()
         >> hasher.update_normals()
         >> hasher.update_uvmap()
-        >> hasher.hash()
+        >> hasher.digest()
         {'normals': 'c41MSCnAGqWS9dBDDpydbpcMwzzFkGH66jNpuTqctfY...',
          'points': 'c44fV5wa6bNiekUadZ4HsRPDL2HZ11RFKcXhf3pntsUJ...',
          'uvmap': 'c45JRQTPxgMNYfcijAbm31vkJRt6CUUSn7ew2X1Mnyjwi...'}
@@ -48,7 +48,7 @@ class MeshHasher(object):
         ...    hasher.update_points()
         ...    hasher.update_normals()
         ...
-        >> hasher.hash()
+        >> hasher.digest()
         {'normals': 'c456rBNH5pzobqjHzFnHApanrTdJo64r2R8o4GJxqU9G...',
          'points': 'c449wXhjNSSKfnUjPp2ub3fd1DeNowW2x5gBJDYrSvxrT...'}
 
@@ -90,23 +90,23 @@ class MeshHasher(object):
         for i, uv in enumerate(zip(*self._mesh.getUVs(uv_set))):
             self._uvmap += _hash_UV(*uv) + i
 
-    def hash(self):
+    def digest(self):
         result = dict()
         hasher = _C4Hasher()
 
         if self._points:
             hasher.hash_obj.update(str(self._points))
-            result["points"] = hasher.hash()
+            result["points"] = hasher.digest()
             hasher.clear()
 
         if self._normals:
             hasher.hash_obj.update(str(self._normals))
-            result["normals"] = hasher.hash()
+            result["normals"] = hasher.digest()
             hasher.clear()
 
         if self._uvmap:
             hasher.hash_obj.update(str(self._uvmap))
-            result["uvmap"] = hasher.hash()
+            result["uvmap"] = hasher.digest()
             hasher.clear()
 
         return result

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -136,7 +136,7 @@ def publish_results_formatting(context):
 def hash_file(file_path):
     hasher = AssetHasher()
     hasher.add_file(file_path)
-    return hasher.hash()
+    return hasher.digest()
 
 
 def plugins_by_range(base=1.5, offset=2, paths=None):
@@ -201,7 +201,7 @@ class _C4Hasher(object):
 
         return result
 
-    def hash(self):
+    def digest(self):
         """Return hash value of data added so far
         """
         c4_id_length = 90
@@ -227,14 +227,14 @@ class AssetHasher(_C4Hasher):
 
         You can keep adding more assets.
         And get the hash value by
-        >> hasher.hash()
+        >> hasher.digest()
         'c463d2Wh5NyBMQRHyxbdBxCzZfaKXvBQaawgfgG18moxQU2jdmaSbCWL...'
 
         You can still adding more assets at this point
         >> hasher.add_file("/path/to/more/file")
 
         And get the hash value of all asset added so far
-        >> hasher.hash()
+        >> hasher.digest()
         'c43cysVyTd7kYurvAa5ooR6miJJgUZ9QnBCHZeNK3en9aQ96KHsoJyJX...'
 
         Until you call `clear`

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -169,32 +169,7 @@ def plugins_by_range(base=1.5, offset=2, paths=None):
     return plugins
 
 
-class AssetHasher(object):
-    """A data hasher for digital content creation
-
-    This is a Python implemtation of Avalanche-io C4 Asset ID.
-
-    Usage:
-        >> hasher = AssetHasher()
-        >> hasher.add_file("/path/to/file")
-        >> hasher.add_dir("/path/to/dir")
-
-        You can keep adding more assets.
-        And get the hash value by
-        >> hasher.hash()
-        'c463d2Wh5NyBMQRHyxbdBxCzZfaKXvBQaawgfgG18moxQU2jdmaSbCWL...'
-
-        You can still adding more assets at this point
-        >> hasher.add_file("/path/to/more/file")
-
-        And get the hash value of all asset added so far
-        >> hasher.hash()
-        'c43cysVyTd7kYurvAa5ooR6miJJgUZ9QnBCHZeNK3en9aQ96KHsoJyJX...'
-
-        Until you call `clear`
-        >> hasher.clear()
-
-    """
+class _C4Hasher(object):
 
     CHUNK_SIZE = 4096 * 10  # magic number
     PREFIX = "c4"
@@ -238,6 +213,34 @@ class AssetHasher(object):
 
         c4id = self.PREFIX + padding + b58_hash
         return c4id
+
+
+class AssetHasher(_C4Hasher):
+    """A data hasher for digital content creation
+
+    This is a Python implemtation of Avalanche-io C4 Asset ID.
+
+    Usage:
+        >> hasher = AssetHasher()
+        >> hasher.add_file("/path/to/file")
+        >> hasher.add_dir("/path/to/dir")
+
+        You can keep adding more assets.
+        And get the hash value by
+        >> hasher.hash()
+        'c463d2Wh5NyBMQRHyxbdBxCzZfaKXvBQaawgfgG18moxQU2jdmaSbCWL...'
+
+        You can still adding more assets at this point
+        >> hasher.add_file("/path/to/more/file")
+
+        And get the hash value of all asset added so far
+        >> hasher.hash()
+        'c43cysVyTd7kYurvAa5ooR6miJJgUZ9QnBCHZeNK3en9aQ96KHsoJyJX...'
+
+        Until you call `clear`
+        >> hasher.clear()
+
+    """
 
     def add_file(self, file_path):
         """Add one file to hasher

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -186,12 +186,12 @@ class _C4Hasher(object):
     def _b58encode(self, bytes):
         """Base58 Encode bytes to string
         """
-        b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+        b58chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
         b58base = 58
 
         long_value = int(codecs.encode(bytes, "hex_codec"), 16)
 
-        result = ''
+        result = ""
         while long_value >= b58base:
             div, mod = divmod(long_value, b58base)
             result = b58chars[mod] + result

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -158,7 +158,7 @@ def test_asset_hasher():
     file_path = os.path.join(wdir, "foo.bar")
 
     # This data happens to be able to cover the if-statement inside
-    # `AssetHasher.hash()`:
+    # `AssetHasher.digest()`:
     # ```
     # if len(b58_hash) < (c4_id_length - 2):
     #     padding = "1" * (c4_id_length - 2 - len(b58_hash))
@@ -171,7 +171,7 @@ def test_asset_hasher():
     hasher = reveries.utils.AssetHasher()
     hasher.add_file(file_path)
 
-    hash_val = hasher.hash()
+    hash_val = hasher.digest()
     assert hash_val.startswith("c4")
 
     hasher.clear()
@@ -181,7 +181,7 @@ def test_asset_hasher():
     dir_path = os.path.dirname(reveries.__file__)
     hasher.add_dir(dir_path)
 
-    hash_val = hasher.hash()
+    hash_val = hasher.digest()
     assert hash_val.startswith("c4")
 
     hasher.clear()
@@ -190,7 +190,7 @@ def test_asset_hasher():
     #
     hasher.add_dir(dir_path, recursive=False)
 
-    hash_val = hasher.hash()
+    hash_val = hasher.digest()
     assert hash_val.startswith("c4")
 
     hasher.clear()


### PR DESCRIPTION
* 增加了 Container interface
    這是一個給 Artist 方便在 Maya Outline 檢視 Asset 重要節點的管道

* 實驗性的加入了 Mesh Hashing
    為了快速確認場景模型是否有在 SetDressing 的時候被修改，效能方面應該是沒問題，1秒即可求出九百萬面模型的頂點位置，法向量，以及 UV 等三個哈希值。 (Maya Python API 神速~)

* 增加了 `SetsLoader`
    這個 Loader 是為了 SetDress 而生的，載入的 Asset 可以自動放置到鏡頭的 `CenterOfInterest` 位置，如此便不需要每次載入新的 Asset 時還要回到世界中心點去抓它。

* 加入 Camera `CenterOfInterest` 的檢查
    若 `CenterOfInterest` 值為 `NaN` 則不可 Pass

* 加入 模型 Lamina face 的檢查
   Lamina face (兩個以上的面分享共同的點和線) 不可 Pass
