### PR TITLE
Improved cross layer querying on renderSetup; Extra resolution for turntable rendering

### DIFF
--- a/plugins/maya/publish/extract_rig.py
+++ b/plugins/maya/publish/extract_rig.py
@@ -42,8 +42,6 @@ class ExtractRig(PackageExtractor):
             maya.maintained_selection(),
             capsule.assign_shader(mesh_nodes, shadingEngine=clay_shader),
         ):
-            cmds.select(self.member, noExpand=True)
-
             with capsule.undo_chunk_when_no_undo():
                 # (NOTE) Current workflow may keep model stay loaded and
                 #   referenced in scene, but need to take extra care while
@@ -81,6 +79,8 @@ class ExtractRig(PackageExtractor):
                 #   So we just remove them all for good.
                 for container in self.context.data["RootContainers"]:
                     cmds.delete(container)
+
+                cmds.select(cmds.ls(self.member), noExpand=True)
 
                 cmds.file(entry_path,
                           force=True,

--- a/plugins/maya/publish/validate_render_resolution.py
+++ b/plugins/maya/publish/validate_render_resolution.py
@@ -1,5 +1,6 @@
 
 import pyblish.api
+from avalon import io
 from reveries.maya import utils as maya_utils
 from reveries.maya import pipeline
 from reveries import utils
@@ -23,17 +24,55 @@ class ValidateRenderResolution(pyblish.api.InstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
         """Rendering resolution should be the same as project settings"""
+        valid_resolutions = list()
+
         project = instance.context.data["projectDoc"]
-        asset_name = pipeline.has_turntable()
+        is_turntable = pipeline.has_turntable()
+
+        turntable = project["data"]["pipeline"]["maya"].get("turntable")
+        if turntable is not None and turntable == is_turntable:
+            # (NOTE) When publishing turntable, some asset may need other
+            #        render resolution width/height to fit in.
+            #
+            #        To add extra valid resolution for asset, add this to
+            #        the turntable asset data:
+            #
+            #           "exceptions" : {
+            #               "assetName": [
+            #                   [width1, height1],
+            #                   [width2, height2],
+            #                   ...
+            #                ]
+            #            }
+            #
+            # (TODO) Might need to think a better way to implement this.
+            #
+            ttable_doc = io.find_one({"type": "asset",
+                                      "name": turntable})
+            ttable_data = ttable_doc["data"]
+            exception = ttable_data["exceptions"].get(instance.data["asset"])
+            if exception is not None:
+                valid_resolutions += exception.get("resolution", [])
+
         proj_width, proj_height = utils.get_resolution_data(project,
-                                                            asset_name)
+                                                            is_turntable)
+        valid_resolutions.append((proj_width, proj_height))
+
         layer = instance.data["renderlayer"]
         scene_width, scene_height = maya_utils.get_render_resolution(layer)
 
-        if proj_width != scene_width or proj_height != scene_height:
+        invalid = True
+        for res in valid_resolutions:
+            if res[0] == scene_width or res[1] == scene_height:
+                invalid = False
+                break
+
+        if invalid:
             cls.log.error("Resolution width and height should be {0} x {1}."
-                          "".format(proj_width, proj_height))
-            return True
+                          "".format(valid_resolutions.pop()))
+            for res in valid_resolutions:
+                cls.log.error("Or {0} x {1}".format(res))
+        return invalid
 
     def process(self, instance):
         self.log.info("Validating image resolution..")

--- a/plugins/maya/publish/validate_rig_contents.py
+++ b/plugins/maya/publish/validate_rig_contents.py
@@ -94,7 +94,7 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
                 continue
 
             for chd in children:
-                if not cmds.nodeType(chd) == "mesh":
+                if not cmds.ls(chd, type=("mesh", "constraint")):
                     invalid.append(node)
                     break
 

--- a/plugins/maya/publish/validate_transform_freezed.py
+++ b/plugins/maya/publish/validate_transform_freezed.py
@@ -75,6 +75,13 @@ class ValidateTranformFreezed(pyblish.api.InstancePlugin):
 
         for transform in transforms:
 
+            if cmds.listConnections(transform,
+                                    source=True,
+                                    destination=False,
+                                    type="constraint"):
+                # Skip constrainted
+                continue
+
             matrix = cmds.xform(transform,
                                 query=True,
                                 matrix=True,


### PR DESCRIPTION
*  Fixed and improved cross layer querying on renderSetup
    Tested on querying absolute and relative override, and attribute like `translate` `translateX` mixed.
    But did not take localRender in logic currently.

* Extra resolution for turntable rendering, see `NOTE` in 4d98258