### PR TITLE
 Re-implement the imgseq publish workflow

### DIFF
--- a/plugins/maya/create/create_render.py
+++ b/plugins/maya/create/create_render.py
@@ -18,14 +18,14 @@ avalon_instance_id = "pyblish.avalon.instance"
 class RenderCreator(avalon.maya.Creator):
     """Create image sequence from rendering or playblast
 
-    Extract image sequence for each renderlayer.
+    Each imgseq objectSet should contain one camera.
 
-    No matter it's rendering or playblast, no need to select camera or
-    pick one into objectSet, just set one camera to be renderabled for
-    each renderlayer.
+    Since the camera and the image sequence has direct input-output
+    relation, the imgseq subset name should be related to camera subset
+    name.
 
-    The instance of this family can be empty, and wont have any affect
-    if it's not.
+    * Playblast should only be extracted from masterLayer.
+    * Render type subset will be suffix with renderlayer name, if used.
 
     """
 
@@ -64,6 +64,7 @@ class RenderCreator(avalon.maya.Creator):
         # Return if existed
         instance = lib.lsAttrs({"id": avalon_instance_id,
                                 "family": self.family,
+                                "subset": self.data["subset"],
                                 "renderType": variant})
         if instance:
             self.log.warning("Already existed.")

--- a/plugins/maya/publish/collect_avalon_instances.py
+++ b/plugins/maya/publish/collect_avalon_instances.py
@@ -24,10 +24,6 @@ class CollectAvalonInstances(pyblish.api.ContextPlugin):
     hosts = ["maya"]
     label = "Avalon Instances"
 
-    allow_empty = [
-        "reveries.imgseq",
-    ]
-
     branched = {
         "reveries.imgseq": "renderType",
         "reveries.xgen": "XGenType",
@@ -64,9 +60,8 @@ class CollectAvalonInstances(pyblish.api.ContextPlugin):
             assert has_family, "\"%s\" was missing a family" % objset
 
             # verify objectSet has members to collect
-            family = cmds.getAttr(objset + ".family")
             members = cmds.sets(objset, query=True)
-            if members is None and family not in self.allow_empty:
+            if members is None:
                 self.log.warning("Skipped empty Set: \"%s\" " % objset)
                 continue
 
@@ -75,6 +70,7 @@ class CollectAvalonInstances(pyblish.api.ContextPlugin):
             data["setMembers"] = members
 
             # Inject shadow family
+            family = cmds.getAttr(objset + ".family")
             if family in self.branched:
                 entry = self.branched[family]
                 shadow_family = family + "." + data[entry]

--- a/plugins/maya/publish/extract_camera.py
+++ b/plugins/maya/publish/extract_camera.py
@@ -5,7 +5,7 @@ import contextlib
 import pyblish.api
 import avalon
 
-from reveries.maya import io, lib, capsule
+from reveries.maya import io, lib, capsule, utils
 from reveries.plugins import PackageExtractor
 
 from maya import cmds
@@ -33,6 +33,8 @@ class ExtractCamera(PackageExtractor):
         self.start = context_data.get("startFrame")
         self.end = context_data.get("endFrame")
         camera = cmds.ls(self.member, type="camera")[0]
+
+        self.camera_uuid = utils.get_id(camera)
 
         with contextlib.nested(
             capsule.no_refresh(),
@@ -74,6 +76,7 @@ class ExtractCamera(PackageExtractor):
 
         self.add_data({
             "entryFileName": entry_file,
+            "cameraUUID": self.camera_uuid,
         })
 
     def extract_Alembic(self):
@@ -87,6 +90,7 @@ class ExtractCamera(PackageExtractor):
 
         self.add_data({
             "entryFileName": entry_file,
+            "cameraUUID": self.camera_uuid,
         })
 
     def extract_FBX(self):
@@ -101,4 +105,5 @@ class ExtractCamera(PackageExtractor):
 
         self.add_data({
             "entryFileName": entry_file,
+            "cameraUUID": self.camera_uuid,
         })

--- a/plugins/maya/publish/extract_playblast.py
+++ b/plugins/maya/publish/extract_playblast.py
@@ -4,7 +4,7 @@ import pyblish.api
 import reveries.utils
 
 from avalon.vendor import clique
-from reveries.maya import io
+from reveries.maya import io, utils
 from reveries.plugins import DelegatablePackageExtractor, skip_stage
 
 
@@ -79,4 +79,5 @@ class ExtractPlayblast(DelegatablePackageExtractor):
             "focalLength": cmds.getAttr(camera + ".focalLength"),
             "resolution": (width, height),
             "fps": self.context.data["fps"],
+            "cameraUUID": utils.get_id(camera),
         })

--- a/plugins/maya/publish/validate_camera_single.py
+++ b/plugins/maya/publish/validate_camera_single.py
@@ -9,7 +9,7 @@ class ValidateSingleCamera(pyblish.api.InstancePlugin):
 
     order = pyblish.api.ValidatorOrder
     hosts = ["maya"]
-    label = "Single Camera"
+    label = "Export Only One Camera"
     families = [
         "reveries.camera",
     ]

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -542,7 +542,7 @@ def compose_render_filename(layer, renderpass="", camera="", on_frame=None):
             for tag in ("<Layer>", "<layer>", "%l"):
                 # We need to replace renderlayer tag by ourself if we don't
                 # switch renderlayer.
-                prefix = prefix.replace(tag, layer)
+                prefix = prefix.replace(tag, lib.pretty_layer_name(layer))
             prefix = mel.eval("vrayTransformFilename("
                               "\"{0}\", \"{1}\", \"{2}\", 0, 0, 0)"
                               "".format(prefix, camera, scene_name))


### PR DESCRIPTION
### Camera oriented, not renderLayer

Since the camera and the image sequence has direct input-output relation, each imgseq should have one and only one camera, the output subset is the render result of that camera.

*Not categorized as renderLayer.*

I think this is a good concept for managing image sequences.
