### PR TITLE
Assign looks via namespaces and using UV hash as hint

### DIFF
--- a/reveries/maya/tools/mayalookassigner/app.py
+++ b/reveries/maya/tools/mayalookassigner/app.py
@@ -116,6 +116,9 @@ class App(QtWidgets.QWidget):
             lambda: self.echo("Loaded assets.."))
 
         self.look_outliner.menu_apply_action.connect(self.on_process_selected)
+        self.look_outliner.menu_apply_via_uv_action.connect(
+            lambda: self.on_process_selected(uv=True)
+        )
         self.remove_unused.clicked.connect(commands.remove_unused_looks)
 
         # Maya renderlayer switch callback
@@ -167,7 +170,7 @@ class App(QtWidgets.QWidget):
         self.look_outliner.clear()
         self.look_outliner.add_items(items)
 
-    def on_process_selected(self):
+    def on_process_selected(self, uv=False):
         """Process all selected looks for the selected assets"""
 
         assets = self.asset_outliner.get_selected_items()
@@ -202,7 +205,8 @@ class App(QtWidgets.QWidget):
             # Assign look
             namespaces = item.get("namespace", item["namespaces"])
             commands.assign_look(namespaces=namespaces,
-                                 look=assign_look)
+                                 look=assign_look,
+                                 via_uv=uv)
 
         end = time.time()
 

--- a/reveries/maya/tools/mayalookassigner/widgets.py
+++ b/reveries/maya/tools/mayalookassigner/widgets.py
@@ -161,6 +161,7 @@ class AssetOutliner(QtWidgets.QWidget):
 class LookOutliner(QtWidgets.QWidget):
 
     menu_apply_action = QtCore.Signal()
+    menu_apply_via_uv_action = QtCore.Signal()
 
     def __init__(self, parent=None):
         QtWidgets.QWidget.__init__(self, parent)
@@ -230,5 +231,12 @@ class LookOutliner(QtWidgets.QWidget):
         apply_action.triggered.connect(self.menu_apply_action)
 
         menu.addAction(apply_action)
+
+        # Assign via UUID-UV relation
+        apply_via_uv_action = QtWidgets.QAction(menu,
+                                                text="Assign looks via UV..")
+        apply_via_uv_action.triggered.connect(self.menu_apply_via_uv_action)
+
+        menu.addAction(apply_via_uv_action)
 
         menu.exec_(globalpos)


### PR DESCRIPTION
As long as there's one set of model's Avalon UUID is correct, the rest of the models can compare with thier UV hashes and use that as a hint to apply look.