### PR TITLE
Implement Arnold Stand-In content cycle; A few improvements

### DIFF
--- a/plugins/maya/create/create_arnold_standin.py
+++ b/plugins/maya/create/create_arnold_standin.py
@@ -1,0 +1,19 @@
+
+import avalon.maya
+
+from reveries.maya.pipeline import put_instance_icon
+
+
+class ArnoldStandInCreator(avalon.maya.Creator):
+    """Arnold stand-in render proxy
+    """
+
+    label = "Arnold Stand-In"
+    family = "reveries.standin"
+    icon = "coffee"
+
+    def process(self):
+
+        self.data["staticCache"] = True
+
+        return put_instance_icon(super(ArnoldStandInCreator, self).process())

--- a/plugins/maya/load/load_arnold_standin.py
+++ b/plugins/maya/load/load_arnold_standin.py
@@ -1,0 +1,50 @@
+
+import avalon.api
+
+import reveries.maya.lib
+from reveries.maya.plugins import ReferenceLoader
+
+
+class ArnoldStandInLoader(ReferenceLoader, avalon.api.Loader):
+
+    label = "Reference Arnold Stand-In"
+    order = -10
+    icon = "coffee"
+    color = "orange"
+
+    hosts = ["maya"]
+
+    families = [
+        "reveries.standin",
+    ]
+
+    representations = [
+        "Ass",
+    ]
+
+    def process_reference(self, context, name, namespace, group, options):
+        import maya.cmds as cmds
+        from reveries.maya.lib import get_highest_in_hierarchy
+
+        representation = context["representation"]
+
+        entry_path = self.file_path(representation)
+
+        nodes = cmds.file(entry_path,
+                          namespace=namespace,
+                          ignoreVersion=True,
+                          sharedReferenceFile=False,
+                          groupReference=True,
+                          groupName=group,
+                          reference=True,
+                          lockReference=False,
+                          returnNewNodes=True)
+
+        reveries.maya.lib.lock_transform(group)
+        self[:] = nodes
+
+        transforms = cmds.ls(nodes, type="transform", long=True)
+        self.interface = get_highest_in_hierarchy(transforms)
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/plugins/maya/load/load_pointcache.py
+++ b/plugins/maya/load/load_pointcache.py
@@ -46,7 +46,7 @@ class PointCacheReferenceLoader(ReferenceLoader, avalon.api.Loader):
                           groupReference=True,
                           groupName=group,
                           reference=True,
-                          lockReference=True,
+                          lockReference=False,
                           returnNewNodes=True)
 
         reveries.maya.lib.lock_transform(group)

--- a/plugins/maya/publish/collect_arnold_standin.py
+++ b/plugins/maya/publish/collect_arnold_standin.py
@@ -1,0 +1,43 @@
+
+import pyblish.api
+from maya import cmds
+
+
+class CollectArnoldStandIn(pyblish.api.InstancePlugin):
+    """Collect mesh's shading network and objectSets
+    """
+
+    order = pyblish.api.CollectorOrder + 0.2
+    hosts = ["maya"]
+    label = "Collect Arnold Stand-In"
+    families = [
+        "reveries.standin"
+    ]
+
+    def process(self, instance):
+        surfaces = cmds.ls(instance,
+                           noIntermediate=True,
+                           type="surfaceShape")
+
+        # Collect shading networks
+        shaders = cmds.listConnections(surfaces, type="shadingEngine")
+        try:
+            _history = cmds.listHistory(shaders)
+        except RuntimeError:
+            _history = []  # Found no items to list the history for.
+        upstream_nodes = cmds.ls(_history, long=True)
+
+        instance.data["fileNodes"] = cmds.ls(upstream_nodes, type="file")
+        instance.data["relativeRoot"] = "$AVALON_PROJECTS\$AVALON_PROJECT"
+        instance.data["replaceRoot"] = "[AVALON_PROJECTS]/[AVALON_PROJECT]"
+
+        # Frame range
+        if instance.data["staticCache"]:
+            instance.data["startFrame"] = cmds.currentTime(query=True)
+            instance.data["endFrame"] = cmds.currentTime(query=True)
+        else:
+            get = (lambda f: cmds.playbackOptions(query=True, **f))
+            instance.data["startFrame"] = get({"minTime": True})
+            instance.data["endFrame"] = get({"maxTime": True})
+
+        instance.data["byFrameStep"] = 1

--- a/plugins/maya/publish/extract_arnold_standin.py
+++ b/plugins/maya/publish/extract_arnold_standin.py
@@ -1,0 +1,99 @@
+
+import os
+import contextlib
+
+import pyblish.api
+from reveries.plugins import PackageExtractor
+from reveries.maya import io, capsule
+
+from maya import cmds
+
+
+@contextlib.contextmanager
+def unlock_colorspace(node):
+    """
+    """
+    color_attr = node + ".colorSpace"
+    color_space = cmds.getAttr(color_attr)
+    cmds.setAttr(color_attr, lock=False)
+    try:
+        yield
+    finally:
+        cmds.setAttr(color_attr, color_space, lock=False, type="string")
+
+
+@contextlib.contextmanager
+def remove_file_env_path(data):
+    """
+    """
+    root = data["relativeRoot"]
+    replace = data["replaceRoot"]
+
+    for node in data["fileNodes"]:
+        # Must be starts with `root`, validated.
+        origin_path = cmds.getAttr(node + ".fileTextureName")
+        arnold_path = origin_path.replace(root, replace)
+
+        with unlock_colorspace(node):
+            cmds.setAttr(node + ".fileTextureName",
+                         arnold_path,
+                         type="string")
+    try:
+        yield
+    finally:
+        for node in data["fileNodes"]:
+            arnold_path = cmds.getAttr(node + ".fileTextureName")
+            origin_path = arnold_path.replace(replace, root)
+            with unlock_colorspace(node):
+                cmds.setAttr(node + ".fileTextureName",
+                             origin_path,
+                             type="string")
+
+
+class ExtractArnoldStandIn(PackageExtractor):
+    """
+    """
+
+    order = pyblish.api.ExtractorOrder
+    hosts = ["maya"]
+    label = "Extract Arnold Stand-In"
+    families = [
+        "reveries.standin"
+    ]
+
+    representations = [
+        "Ass",
+    ]
+
+    def extract_Ass(self):
+        entry_file = self.file_name("ma")
+        cache_file = self.file_name("ass")
+        package_path = self.create_package()
+        entry_path = os.path.join(package_path, entry_file)
+        cache_path = os.path.join(package_path, cache_file)
+
+        with contextlib.nested(
+            capsule.no_undo(),
+            capsule.no_refresh(),
+            capsule.evaluation("off"),
+            capsule.maintained_selection(),
+            capsule.ref_edit_unlock(),
+            remove_file_env_path(self.data),
+        ):
+            cmds.select(self.member, replace=True)
+            asses = cmds.arnoldExportAss(filename=cache_path,
+                                         selected=True,
+                                         startFrame=self.data["startFrame"],
+                                         endFrame=self.data["endFrame"],
+                                         frameStep=self.data["byFrameStep"],
+                                         shadowLinks=1,
+                                         lightLinks=1,
+                                         mask=24)
+
+        use_sequence = self.data["startFrame"] != self.data["endFrame"]
+        cache_file = os.path.basename(asses[0])
+        io.wrap_ass(entry_path,
+                    [(cache_file, self.data["subset"])],
+                    [use_sequence])
+
+        self.add_data({"entryFileName": entry_file})

--- a/plugins/maya/publish/extract_setdress.py
+++ b/plugins/maya/publish/extract_setdress.py
@@ -27,7 +27,6 @@ class ExtractSetDress(PackageExtractor):
 
     representations = [
         "setPackage",
-        "GPUCache",
     ]
 
     def _collect_components_matrix(self, data, container):
@@ -117,24 +116,3 @@ class ExtractSetDress(PackageExtractor):
         self.log.debug("Exported: {}".format(entry_path))
 
         cmds.select(clear=True)
-
-    def extract_GPUCache(self):
-        entry_file = self.file_name("ma")
-        cache_file = self.file_name("abc")
-        package_path = self.create_package()
-        entry_path = os.path.join(package_path, entry_file)
-        cache_path = os.path.join(package_path, cache_file)
-
-        cmds.select(self.data["subsetSlots"])
-
-        self.log.info("Extracting setDress GPUCache ..")
-
-        frame = cmds.currentTime(query=True)
-        io.export_gpu(cache_path, frame, frame)
-        io.wrap_gpu(entry_path, [(cache_file, self.data["subset"])])
-
-        self.add_data({
-            "entryFileName": entry_file,
-        })
-
-        self.log.debug("Exported: {}".format(entry_path))

--- a/plugins/maya/publish/validate_no_foster_parent.py
+++ b/plugins/maya/publish/validate_no_foster_parent.py
@@ -1,0 +1,38 @@
+
+import pyblish.api
+from reveries.maya.plugins import MayaSelectInvalidInstanceAction
+
+
+class SelectFosterParent(MayaSelectInvalidInstanceAction):
+
+    label = "Select Foster Parent"
+
+
+class ValidateNoFosterParent(pyblish.api.InstancePlugin):
+    """No fosterParent node in hierarchy
+
+    Should not contain any fosterParent node in DAG hierarchy. If so,
+    please reslove the referencing issue or just delete it if not used.
+
+    """
+
+    order = pyblish.api.ValidatorOrder
+    hosts = ["maya"]
+    label = "No Foster Parent"
+    families = [
+        "reveries.model",
+        "reveries.rig",
+    ]
+    actions = [
+        pyblish.api.Category("Select"),
+        SelectFosterParent,
+    ]
+
+    @classmethod
+    def get_invalid(cls, instance):
+        from maya import cmds
+        return cmds.ls(instance, type="fosterParent")
+
+    def process(self, instance):
+        if self.get_invalid(instance):
+            raise Exception("Found 'fosterParent' nodes.")

--- a/plugins/maya/publish/validate_versioned_surfaces.py
+++ b/plugins/maya/publish/validate_versioned_surfaces.py
@@ -21,6 +21,7 @@ class ValidateVersionedSurfaces(pyblish.api.InstancePlugin):
     label = "Has Versioned Surfaces"
     families = [
         "reveries.imgseq",
+        "reveries.standin",
     ]
 
     actions = [
@@ -53,7 +54,7 @@ class ValidateVersionedSurfaces(pyblish.api.InstancePlugin):
 
         not_containerized = transforms - has_versioned
         other_instances = [i for i in instance.context
-                           if (not i.data["family"] == "reveries.imgseq" and
+                           if (i.data["family"] not in cls.families and
                                i.data.get("publish", True))]
         # Is node being publish ?
         for node in not_containerized:

--- a/plugins/maya/publish/validate_versioned_textures.py
+++ b/plugins/maya/publish/validate_versioned_textures.py
@@ -1,0 +1,53 @@
+
+import pyblish.api
+from reveries.maya.plugins import MayaSelectInvalidInstanceAction
+
+
+class SelectInvalid(MayaSelectInvalidInstanceAction):
+
+    label = "Select Not Versioned"
+
+
+class ValidateVersionedTextures(pyblish.api.InstancePlugin):
+    """All surface node in scene should be part of versioned subset
+
+    Should be containerized or instance that is going to be published
+
+    """
+
+    order = pyblish.api.ValidatorOrder
+    hosts = ["maya"]
+    label = "Has Versioned Textures"
+    families = [
+        "reveries.standin",
+    ]
+
+    actions = [
+        pyblish.api.Category("Select"),
+        SelectInvalid,
+    ]
+
+    @classmethod
+    def get_invalid(cls, instance):
+        from maya import cmds
+
+        files = set(instance.data["fileNodes"])
+        root = instance.data["relativeRoot"]
+
+        has_versioned = set()
+        for node in files:
+            if cmds.getAttr(node + ".fileTextureName").startswith(root):
+                # As long as the texture file path starts with project
+                # env vars, consider it's been published.
+                has_versioned.add(node)
+
+        not_versioned = files - has_versioned
+
+        return list(not_versioned)
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            for i in invalid:
+                self.log.error(i)
+            raise Exception("Texture node not versioned.")

--- a/res/.config.toml
+++ b/res/.config.toml
@@ -96,6 +96,11 @@ label = "Light Set"
 icon = "lightbulb-o"
 
 [[families]]
+name = "reveries.standin"
+label = "Arnold Stand-In"
+icon = "coffee"
+
+[[families]]
 name = "reveries.mayashare"
 label = "Maya Share (.ma)"
 icon = "share-square-o"

--- a/reveries/maya/capsule.py
+++ b/reveries/maya/capsule.py
@@ -369,6 +369,17 @@ def nodes_locker(nodes, lock=True, lockName=True, lockUnpublished=True):
         lib.restore_lock_state(lock_state)
 
 
+@contextlib.contextmanager
+def ref_edit_unlock():
+    ref_lock = cmds.optionVar(query="refLockEditable")
+    try:
+        cmds.optionVar(intValue=("refLockEditable", 1))
+        yield
+
+    finally:
+        cmds.optionVar(intValue=("refLockEditable", ref_lock))
+
+
 class delete_after(object):
     """Context Manager that will delete collected nodes after exit.
 


### PR DESCRIPTION
### Arnold Stand-In content cycle
* Only extract model and looks (`arnoldExportAss -mode 24`)
* The texture file path in `.ass` is env var prefixed: `[AVALON_PROJECTS]/[AVALON_PROJECT]/...`
* Models and looks must be published
* Sequence export supported