### PR TITLE
Deprecate interface nodes

### DIFF
--- a/plugins/maya/load/load_arnold_standin.py
+++ b/plugins/maya/load/load_arnold_standin.py
@@ -24,7 +24,6 @@ class ArnoldStandInLoader(ReferenceLoader, avalon.api.Loader):
 
     def process_reference(self, context, name, namespace, group, options):
         import maya.cmds as cmds
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -42,9 +41,6 @@ class ArnoldStandInLoader(ReferenceLoader, avalon.api.Loader):
 
         reveries.maya.lib.lock_transform(group)
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        self.interface = get_highest_in_hierarchy(transforms)
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_camera.py
+++ b/plugins/maya/load/load_camera.py
@@ -42,8 +42,5 @@ class CameraLoader(ReferenceLoader, avalon.api.Loader):
         reveries.maya.lib.lock_transform(group)
         self[:] = nodes
 
-        self.interface = cmds.listRelatives(cmds.ls(nodes, type="camera"),
-                                            parent=True)
-
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_lightSet.py
+++ b/plugins/maya/load/load_lightSet.py
@@ -23,7 +23,6 @@ class LightSetLoader(ReferenceLoader, avalon.api.Loader):
 
         import maya.cmds as cmds
         from avalon import maya
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -38,9 +37,6 @@ class LightSetLoader(ReferenceLoader, avalon.api.Loader):
                               groupReference=True,
                               groupName=group)
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        self.interface = get_highest_in_hierarchy(transforms)
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_look.py
+++ b/plugins/maya/load/load_look.py
@@ -52,13 +52,6 @@ class LookLoader(ReferenceLoader, avalon.api.Loader):
 
         self[:] = nodes
 
-        shading_engines = cmds.ls(nodes, type="shadingEngine")
-        shaders = list()
-        for node in shading_engines:
-            shaders += cmds.listConnections(node + ".surfaceShader")
-
-        self.interface = shading_engines + shaders
-
     def update(self, container, representation):
         """Update look assignment
 

--- a/plugins/maya/load/load_model.py
+++ b/plugins/maya/load/load_model.py
@@ -23,7 +23,6 @@ class ModelLoader(ReferenceLoader, avalon.api.Loader):
 
         import maya.cmds as cmds
         from avalon import maya
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -38,9 +37,6 @@ class ModelLoader(ReferenceLoader, avalon.api.Loader):
                               groupReference=True,
                               groupName=group)
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        self.interface = get_highest_in_hierarchy(transforms)
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_pointcache.py
+++ b/plugins/maya/load/load_pointcache.py
@@ -27,7 +27,6 @@ class PointCacheReferenceLoader(ReferenceLoader, avalon.api.Loader):
 
     def process_reference(self, context, name, namespace, group, options):
         import maya.cmds as cmds
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -45,9 +44,6 @@ class PointCacheReferenceLoader(ReferenceLoader, avalon.api.Loader):
 
         reveries.maya.lib.lock_transform(group)
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        self.interface = get_highest_in_hierarchy(transforms)
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_rig.py
+++ b/plugins/maya/load/load_rig.py
@@ -27,7 +27,6 @@ class RigLoader(ReferenceLoader, avalon.api.Loader):
     def process_reference(self, context, name, namespace, group, options):
 
         import maya.cmds as cmds
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -42,11 +41,6 @@ class RigLoader(ReferenceLoader, avalon.api.Loader):
                           groupName=group)
 
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        root = get_highest_in_hierarchy(transforms)
-        sets = cmds.ls(nodes, type="objectSet")
-        self.interface = root + sets
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_xgen_interactive.py
+++ b/plugins/maya/load/load_xgen_interactive.py
@@ -1,7 +1,6 @@
 
 import avalon.api
 from reveries.maya.plugins import ReferenceLoader
-from reveries.maya.xgen.interactive import list_lead_descriptions
 
 
 class XGenInteractiveLoader(ReferenceLoader, avalon.api.Loader):
@@ -24,7 +23,6 @@ class XGenInteractiveLoader(ReferenceLoader, avalon.api.Loader):
 
         import maya.cmds as cmds
         from avalon import maya
-        from reveries.maya.lib import get_highest_in_hierarchy
 
         representation = context["representation"]
 
@@ -39,12 +37,6 @@ class XGenInteractiveLoader(ReferenceLoader, avalon.api.Loader):
                               groupReference=True,
                               groupName=group)
         self[:] = nodes
-
-        transforms = cmds.ls(nodes, type="transform", long=True)
-        root = get_highest_in_hierarchy(transforms)
-        descriptions = cmds.listRelatives(list_lead_descriptions(nodes),
-                                          parent=True) or []
-        self.interface = root + descriptions
 
     def switch(self, container, representation):
         self.update(container, representation)

--- a/plugins/maya/load/load_xgen_legacy.py
+++ b/plugins/maya/load/load_xgen_legacy.py
@@ -80,7 +80,6 @@ class XGenLegacyLoader(MayaBaseLoader, avalon.api.Loader):
         #        being binded.
 
         # Containerising..
-        self.interface = palette_nodes[:]
         nodes = palette_nodes[:]
         nodes += cmds.listRelatives(palette_nodes,
                                     allDescendents=True,
@@ -92,7 +91,6 @@ class XGenLegacyLoader(MayaBaseLoader, avalon.api.Loader):
                                           namespace=namespace,
                                           container_id=container_id,
                                           nodes=nodes,
-                                          ports=self.interface,
                                           context=context,
                                           cls_name=self.__class__.__name__,
                                           group_name=group_name)

--- a/reveries/maya/callbacks.py
+++ b/reveries/maya/callbacks.py
@@ -92,6 +92,8 @@ def on_open(_):
     cmds.evalDeferred("from reveries.maya import callbacks;"
                       "callbacks._outliner_hide_set_member()")
 
+    maya_utils.drop_interface()
+
 
 def on_save(_):
     avalon.logger.info("Running callback on save..")

--- a/reveries/maya/hierarchy.py
+++ b/reveries/maya/hierarchy.py
@@ -15,8 +15,6 @@ from . import lib
 from . import capsule
 from .pipeline import (
     AVALON_PORTS,
-    AVALON_INTERFACE_ID,
-    get_container_from_interface,
     parse_container,
 )
 
@@ -61,21 +59,21 @@ def walk_containers(container):
             yield sub_con
 
 
-def climb_container_id(interface):
+def climb_container_id(container):
     """Recursively yield container ID from buttom(leaf) to top(root)
 
     Args:
-        interface (str): The interface node name
+        container (str): The container node name
 
     Yields:
         str: container id
 
     """
-    parents = cmds.ls(cmds.listSets(object=interface), type="objectSet")
+    parents = cmds.ls(cmds.listSets(object=container), type="objectSet")
     for m in parents:
-        # Find interface node
+        # Find container node
         if (lib.hasAttr(m, "id") and
-                cmds.getAttr(m + ".id") == AVALON_INTERFACE_ID):
+                cmds.getAttr(m + ".id") == AVALON_CONTAINER_ID):
 
             yield cmds.getAttr(m + ".containerId")
             # Next parent
@@ -83,26 +81,26 @@ def climb_container_id(interface):
                 yield n
 
 
-def walk_container_id(interface):
+def walk_container_id(container):
     """Recursively yield container ID from top(root) to buttom(leaf)
 
     Args:
-        interface (str): The interface node name
+        container (str): The container node name
 
     Yields:
         str: container id
 
     """
-    parents = cmds.ls(cmds.listSets(object=interface), type="objectSet")
+    parents = cmds.ls(cmds.listSets(object=container), type="objectSet")
     for m in parents:
-        # Find interface node
+        # Find container node
         if (lib.hasAttr(m, "id") and
-                cmds.getAttr(m + ".id") == AVALON_INTERFACE_ID):
+                cmds.getAttr(m + ".id") == AVALON_CONTAINER_ID):
             # Find next parent before yielding `containerId`
             for n in walk_container_id(m):
                 yield n
 
-    yield cmds.getAttr(interface + ".containerId")
+    yield cmds.getAttr(container + ".containerId")
 
 
 def container_to_id_path(container):
@@ -115,7 +113,7 @@ def container_to_id_path(container):
         str: container id path
 
     """
-    return "|".join(walk_container_id(container["interface"]))
+    return "|".join(walk_container_id(container["objectName"]))
 
 
 def container_from_id_path(container_id_path, parent_namespace):
@@ -131,11 +129,11 @@ def container_from_id_path(container_id_path, parent_namespace):
     """
     container_ids = container_id_path.split("|")
 
-    leaf_interfaces = lib.lsAttr("containerId",
+    leaf_containers = lib.lsAttr("containerId",
                                  container_ids.pop(),  # leaf container id
                                  parent_namespace + "::")
 
-    walkers = {leaf: climb_container_id(leaf) for leaf in leaf_interfaces}
+    walkers = {leaf: climb_container_id(leaf) for leaf in leaf_containers}
 
     while container_ids:
         con_id = container_ids.pop()
@@ -156,8 +154,7 @@ def container_from_id_path(container_id_path, parent_namespace):
     if not len(walkers):
         raise RuntimeError("Container not found, this is a bug.")
 
-    interface = list(walkers.keys())[0]
-    container = get_container_from_interface(interface)
+    container = list(walkers.keys())[0]
 
     return container
 

--- a/reveries/maya/hierarchy.py
+++ b/reveries/maya/hierarchy.py
@@ -13,10 +13,7 @@ from ..plugins import message_box_error
 
 from . import lib
 from . import capsule
-from .pipeline import (
-    AVALON_PORTS,
-    parse_container,
-)
+from .pipeline import parse_container
 
 
 _log = logging.getLogger("reveries.maya.hierarchy")
@@ -245,7 +242,6 @@ def add_subset(data, namespace, root, on_update=None):
                                     data["representationDoc"],
                                     namespace=sub_namespace,
                                     options=options)
-    sub_interface = sub_container["interface"]
     subset_group = sub_container["subsetGroup"]
 
     try:
@@ -263,12 +259,10 @@ def add_subset(data, namespace, root, on_update=None):
 
         if on_update is None:
             cmds.sets(sub_container["objectName"], remove=AVALON_CONTAINERS)
-            cmds.sets(sub_interface, remove=AVALON_PORTS)
         else:
             container = on_update
             cmds.sets(sub_container["objectName"],
                       forceElement=container["objectName"])
-            cmds.sets(sub_interface, forceElement=container["interface"])
 
 
 def get_referenced_containers(container):

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -254,7 +254,7 @@ def update_container(container, asset, subset, version, representation):
         "versionId": str(version["_id"]),
         "representation": str(representation["_id"]),
     }.items():
-        cmds.setAttr(container + "." + key, value, type="string")
+        cmds.setAttr(container_node + "." + key, value, type="string")
 
     name = subset["name"]
 

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -279,22 +279,19 @@ def subset_containerising(name,
                           namespace,
                           container_id,
                           nodes,
-                          ports,
                           context,
                           cls_name,
                           group_name):
-    """Containerise loaded subset and build interface
+    """Containerise loaded subset
 
-    Containerizing imported/referenced nodes and creating interface node,
-    and the interface node will connected to container node and top group
-    node's `message` attribute.
+    Containerizing imported/referenced nodes and connect subset group
+    node's `message` attribute to container node.
 
     Arguments:
         name (str): Name of resulting assembly
-        namespace (str): Namespace under which to host interface
+        namespace (str): Namespace under which to host container
         container_id (str): Container UUID
         nodes (list): Long names of imported/referenced nodes
-        ports (list): Long names of nodes for interfacing
         context (dict): Asset information
         cls_name (str): avalon Loader class name
         group_name (str): Top group node of imported/referenced new nodes

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -104,35 +104,6 @@ def unique_root_namespace(asset_name, family_name, parent_namespace=""):
     return ":" + unique  # Ensure in root
 
 
-def get_interface_from_container(container):
-    """Return interface node from container node
-
-    Raise `RuntimeError` if getting none or more then one interface.
-
-    Arguments:
-        container (str): Name of container node
-
-    Returns a str
-
-    """
-    nodes = list()
-
-    for node in cmds.listConnections(container + ".message",
-                                     destination=True,
-                                     source=False,
-                                     type="objectSet"):
-        if not cmds.objExists(node + ".id"):
-            continue
-
-        if cmds.getAttr(node + ".id") == AVALON_INTERFACE_ID:
-            nodes.append(node)
-
-    if not len(nodes) == 1:
-        raise RuntimeError("Container has none or more then one interface, "
-                           "this is a bug.")
-    return nodes[0]
-
-
 def get_container_from_namespace(namespace):
     """Return container node from namespace
 

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -17,7 +17,6 @@ from .. import REVERIES_ICONS, utils
 
 
 AVALON_PORTS = ":AVALON_PORTS"
-AVALON_INTERFACE_ID = "pyblish.avalon.interface"
 
 AVALON_GROUP_ATTR = "subsetGroup"
 AVALON_CONTAINER_ATTR = "container"

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -182,20 +182,24 @@ def get_container_from_group(group):
         str or None
 
     """
-    group = group.rsplit("|", 1)[-1]
-    nodes = lib.lsAttrs({"id": AVALON_INTERFACE_ID,
-                         "subsetGroup": group})
-    if not nodes:
+    if not cmds.objExists(group):
         return None
 
-    assert len(nodes) == 1, ("Group node has more then one interface, "
-                             "this is a bug.")
+    nodes = list()
 
-    source = cmds.listConnections(nodes[0] + ".container",
-                                  source=True,
-                                  destination=False,
-                                  plugs=False)
-    return source[0]
+    for node in cmds.listConnections(group + ".message",
+                                     destination=True,
+                                     source=False,
+                                     type="objectSet"):
+        if not cmds.objExists(node + ".id"):
+            continue
+
+        if cmds.getAttr(node + ".id") == AVALON_CONTAINER_ID:
+            nodes.append(node)
+
+    assert len(nodes) == 1, ("Group node has more then one container, "
+                             "this is a bug.")
+    return nodes[0]
 
 
 def get_group_from_container(container):
@@ -205,11 +209,8 @@ def get_group_from_container(container):
         container (str): Name of container node
 
     """
-    interface = get_interface_from_container(container)
-
     try:
-
-        group = cmds.listConnections(interface + ".subsetGroup",
+        group = cmds.listConnections(container + ".subsetGroup",
                                      source=True,
                                      destination=False,
                                      plugs=False)

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -15,9 +15,6 @@ from .vendor import sticker
 from .capsule import namespaced, nodes_locker
 from .. import REVERIES_ICONS, utils
 
-
-AVALON_PORTS = ":AVALON_PORTS"
-
 AVALON_GROUP_ATTR = "subsetGroup"
 AVALON_CONTAINER_ATTR = "container"
 

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -133,21 +133,6 @@ def get_interface_from_container(container):
     return nodes[0]
 
 
-def get_container_from_interface(interface):
-    """Return container node from interface node
-
-    Raise `RuntimeError` if getting none or more then one container.
-
-    Arguments:
-        interface (str): Name of interface node
-
-    Returns a str
-
-    """
-    namespace = cmds.getAttr(interface + ".namespace")
-    return get_container_from_namespace(namespace)
-
-
 def get_container_from_namespace(namespace):
     """Return container node from namespace
 

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -263,7 +263,6 @@ def update_container(container, asset, subset, version, representation):
     log.info("Updating container...")
 
     container_node = container["objectName"]
-    interface_node = container["interface"]
 
     asset_changed = False
     subset_changed = False
@@ -299,35 +298,33 @@ def update_container(container, asset, subset, version, representation):
         subset_changed = True
         name = subset["name"]
         # Rename group node
-        group = container["subsetGroup"]
-        cmds.rename(group, subset_group_name(namespace, name))
-        # Update data
+        group = container.get("subsetGroup")
+        if group and cmds.objExists(group):
+            cmds.rename(group, subset_group_name(namespace, name))
+        # Update subset name
         cmds.setAttr(container_node + ".name", name, type="string")
 
-    # Update interface data: representation id
+    # Update representation id
     cmds.setAttr(container_node + ".representation",
                  str(representation["_id"]),
                  type="string")
-    # Update interface data: version id
-    cmds.setAttr(interface_node + ".versionId",
+    # Update version id
+    cmds.setAttr(container_node + ".versionId",
                  str(version["_id"]),
                  type="string")
 
     if any((asset_changed, subset_changed)):
-        # Update interface data: subset id
-        cmds.setAttr(interface_node + ".subsetId",
+        # Update subset id
+        cmds.setAttr(container_node + ".subsetId",
                      str(subset["_id"]),
                      type="string")
-        # Update interface data: asset id
-        cmds.setAttr(interface_node + ".assetId",
+        # Update asset id
+        cmds.setAttr(container_node + ".assetId",
                      str(asset["_id"]),
                      type="string")
         # Rename container
         container_node = cmds.rename(
             container_node, container_naming(namespace, name, "CON"))
-        # Rename interface
-        cmds.rename(interface_node,
-                    container_naming(namespace, name, "PORT"))
         # Rename reference node
         reference_node = next((n for n in cmds.sets(container_node, query=True)
                                if cmds.nodeType(n) == "reference"), None)

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -63,8 +63,6 @@ def load_plugin(representation):
 
 class MayaBaseLoader(PackageLoader):
 
-    interface = []
-
     def __init__(self, context):
         from reveries.maya.pipeline import is_editable
         if not is_editable():
@@ -152,7 +150,6 @@ class ReferenceLoader(MayaBaseLoader):
                                           namespace=namespace,
                                           container_id=container_id,
                                           nodes=nodes,
-                                          ports=self.interface,
                                           context=context,
                                           cls_name=self.__class__.__name__,
                                           group_name=group_name)
@@ -203,7 +200,6 @@ class ReferenceLoader(MayaBaseLoader):
         from maya import cmds
 
         node = container["objectName"]
-        interface = container["interface"]
 
         # Get reference node from container members
         members = cmds.sets(node, query=True, nodesOnly=True)
@@ -237,7 +233,6 @@ class ReferenceLoader(MayaBaseLoader):
         holders = (lambda N: [x for x in cmds.sets(N, query=True) or []
                               if ".placeHolderList" in x])
         cmds.sets(holders(node), remove=node)
-        cmds.sets(holders(interface), remove=interface)
 
         # Update container
         version, subset, asset, _ = parents
@@ -316,7 +311,6 @@ class ImportLoader(MayaBaseLoader):
                                           namespace=namespace,
                                           container_id=container_id,
                                           nodes=nodes,
-                                          ports=self.interface,
                                           context=context,
                                           cls_name=self.__class__.__name__,
                                           group_name=group_name)
@@ -452,7 +446,6 @@ class HierarchicalLoader(MayaBaseLoader):
 
         # Load sub-subsets
         sub_containers = []
-        sub_interfaces = []
         for data in members:
 
             repr_id = data["representation"]
@@ -466,10 +459,8 @@ class HierarchicalLoader(MayaBaseLoader):
                                      container=sub_container)
 
             sub_containers.append(sub_container["objectName"])
-            sub_interfaces.append(sub_container["interface"])
 
         self[:] = hierarchy + sub_containers
-        self.interface = [group_name] + sub_interfaces
 
         # Only containerize if any nodes were loaded by the Loader
         nodes = self[:]
@@ -480,7 +471,6 @@ class HierarchicalLoader(MayaBaseLoader):
                                           namespace=namespace,
                                           container_id=container_id,
                                           nodes=nodes,
-                                          ports=self.interface,
                                           context=context,
                                           cls_name=self.__class__.__name__,
                                           group_name=group_name)

--- a/reveries/maya/tools/mayalookassigner/commands.py
+++ b/reveries/maya/tools/mayalookassigner/commands.py
@@ -13,7 +13,6 @@ from ....utils import get_representation_path_
 from ....maya import lib, utils
 from ...pipeline import (
     AVALON_INTERFACE_ID,
-    get_interface_from_container,
     get_container_from_namespace,
     parse_container,
 )
@@ -227,17 +226,15 @@ def list_loaded_looks(asset_id):
     for container in lib.lsAttrs({"id": AVALON_CONTAINER_ID,
                                   "loader": "LookLoader"}):
 
-        interface = get_interface_from_container(container)
-
-        if str(asset_id) == cmds.getAttr(interface + ".assetId"):
-            subset_id = cmds.getAttr(interface + ".subsetId")
+        if str(asset_id) == cmds.getAttr(container + ".assetId"):
+            subset_id = cmds.getAttr(container + ".subsetId")
             if subset_id in cached_look:
                 look = cached_look[subset_id].copy()
             else:
                 look = io.find_one({"_id": io.ObjectId(subset_id)})
                 cached_look[subset_id] = look
 
-            namespace = cmds.getAttr(interface + ".namespace")
+            namespace = cmds.getAttr(container + ".namespace")
             # Example: ":Zombie_look_02_"
             look["No."] = namespace.split("_")[-2]  # result: "02"
             look["namespace"] = namespace

--- a/reveries/maya/tools/mayalookassigner/commands.py
+++ b/reveries/maya/tools/mayalookassigner/commands.py
@@ -12,8 +12,8 @@ from avalon.vendor import six
 from ....utils import get_representation_path_
 from ....maya import lib, utils
 from ...pipeline import (
-    AVALON_INTERFACE_ID,
     get_container_from_namespace,
+    get_group_from_container,
     parse_container,
 )
 
@@ -34,7 +34,7 @@ def select(nodes):
     cmds.select(nodes, noExpand=True)
 
 
-def get_interface_from_namespace(namespaces):
+def get_groups_from_namespaces(namespaces):
     """Return interface nodes from namespace
 
     Args:
@@ -47,15 +47,15 @@ def get_interface_from_namespace(namespaces):
     if isinstance(namespaces, six.string_types):
         namespaces = [namespaces]
 
-    interfaces = list()
+    groups = list()
 
     for namespace in namespaces:
-        interfaces += lib.lsAttrs({"id": AVALON_INTERFACE_ID,
-                                   "namespace": namespace})
+        container = get_container_from_namespace(namespace)
+        group = get_group_from_container(container)
+        if group is not None:
+            groups.append(group)
 
-    return cmds.ls(cmds.sets(interfaces, query=True, nodesOnly=True),
-                   type="transform",
-                   long=True)
+    return groups
 
 
 def list_descendents(nodes):

--- a/reveries/maya/tools/mayalookassigner/commands.py
+++ b/reveries/maya/tools/mayalookassigner/commands.py
@@ -35,13 +35,13 @@ def select(nodes):
 
 
 def get_groups_from_namespaces(namespaces):
-    """Return interface nodes from namespace
+    """Return group nodes from namespace
 
     Args:
         namespaces (str, unicode or set): Target subsets' namespaces
 
     Returns:
-        list: List of interface node in long name
+        list: List of group node in long name
 
     """
     if isinstance(namespaces, six.string_types):

--- a/reveries/maya/tools/mayalookassigner/widgets.py
+++ b/reveries/maya/tools/mayalookassigner/widgets.py
@@ -120,7 +120,7 @@ class AssetOutliner(QtWidgets.QWidget):
             asset_name = item["asset"]["name"]
 
             namespaces = item.get("namespace", item["namespaces"])
-            nodes = commands.get_interface_from_namespace(namespaces)
+            nodes = commands.get_groups_from_namespaces(namespaces)
 
             assets[item.get("namespace") or asset_name] = item
             assets[item.get("namespace") or asset_name]["nodes"] = nodes

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -17,7 +17,11 @@ from maya import cmds, mel
 from maya.api import OpenMaya as om
 from ..vendor import six
 from ..utils import _C4Hasher, get_representation_path_
-from .pipeline import env_embedded_path
+from .pipeline import (
+    env_embedded_path,
+    get_container_from_namespace,
+    AVALON_GROUP_ATTR,
+)
 from . import lib, capsule
 
 
@@ -757,3 +761,44 @@ def update_dependency(container):
               loadReference=reference_node,
               type=file_type,
               defaultExtensions=False)
+
+
+def drop_interface():
+    """Remove deprecated interface nodes from scene
+
+    Transfer data from interface node to container node and delete
+
+    """
+
+    PORTS = ":AVALON_PORTS"
+    INTERFACE = "pyblish.avalon.interface"
+
+    if not cmds.objExists(PORTS):
+        return
+
+    for interface in lib.lsAttr("id", INTERFACE):
+
+        namespace = cmds.getAttr(interface + ".namespace")
+        container = get_container_from_namespace(namespace)
+
+        getter = (lambda a: cmds.getAttr(interface + "." + a))
+
+        for key, value in {
+            "containerId": getter("containerId"),
+            "assetId": getter("assetId"),
+            "subsetId": getter("subsetId"),
+            "versionId": getter("versionId"),
+        }.items():
+            cmds.addAttr(container, longName=key, dataType="string")
+            cmds.setAttr(container + "." + key, value, type="string")
+
+        try:
+            group = cmds.listConnections(interface + ".subsetGroup",
+                                         source=True,
+                                         destination=False)[0]
+        except ValueError:
+            pass
+        else:
+            lib.connect_message(group, container, AVALON_GROUP_ATTR)
+
+        cmds.delete(interface)

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -17,7 +17,7 @@ from maya import cmds, mel
 from maya.api import OpenMaya as om
 from ..vendor import six
 from ..utils import _C4Hasher, get_representation_path_
-from .pipeline import get_interface_from_container, env_embedded_path
+from .pipeline import env_embedded_path
 from . import lib, capsule
 
 
@@ -724,11 +724,9 @@ def update_dependency(container):
 
     version, subset, asset, project = io.parenthood(representation)
 
-    interface = get_interface_from_container(container)
-
-    cmds.setAttr(interface + ".assetId", str(asset["_id"]), type="string")
-    cmds.setAttr(interface + ".subsetId", str(subset["_id"]), type="string")
-    cmds.setAttr(interface + ".versionId", str(version["_id"]), type="string")
+    cmds.setAttr(container + ".assetId", str(asset["_id"]), type="string")
+    cmds.setAttr(container + ".subsetId", str(subset["_id"]), type="string")
+    cmds.setAttr(container + ".versionId", str(version["_id"]), type="string")
 
     # Update Reference path
     reference_node = next(iter(cmds.ls(cmds.sets(container, query=True),


### PR DESCRIPTION
Interface node was rarely used by artist, merge interface data into container and deprecate it for simplicity.