### PR TITLE
Minor improves (Maya)

### DIFF
--- a/plugins/maya/create/create_camera.py
+++ b/plugins/maya/create/create_camera.py
@@ -11,4 +11,5 @@ class CameraCreator(avalon.maya.Creator):
     icon = "video-camera"
 
     def process(self):
+        self.data["bakeStep"] = 1.0
         return put_instance_icon(super(CameraCreator, self).process())

--- a/plugins/maya/publish/extract_camera.py
+++ b/plugins/maya/publish/extract_camera.py
@@ -45,6 +45,7 @@ class ExtractCamera(PackageExtractor):
         context_data = self.context.data
         self.start = context_data.get("startFrame")
         self.end = context_data.get("endFrame")
+        self.step = self.data.get("bakeStep", 1.0)
         camera = cmds.ls(self.member, type="camera", long=True)[0]
 
         self.camera_uuid = utils.get_id(camera)
@@ -58,7 +59,10 @@ class ExtractCamera(PackageExtractor):
             capsule.undo_chunk(),
         ):
             # bake to worldspace
-            baked_camera = lib.bake_camera(camera, self.start, self.end)
+            baked_camera = lib.bake_camera(camera,
+                                           self.start,
+                                           self.end,
+                                           self.step)
 
             cmds.select(baked_camera,
                         hierarchy=True,  # With shape
@@ -90,6 +94,7 @@ class ExtractCamera(PackageExtractor):
             "cameraUUID": self.camera_uuid,
             "startFrame": self.start,
             "endFrame": self.end,
+            "byFrameStep": self.step,
         })
 
     def extract_Alembic(self):
@@ -106,6 +111,7 @@ class ExtractCamera(PackageExtractor):
             "cameraUUID": self.camera_uuid,
             "startFrame": self.start,
             "endFrame": self.end,
+            "byFrameStep": self.step,
         })
 
     def extract_FBX(self):
@@ -123,4 +129,5 @@ class ExtractCamera(PackageExtractor):
             "cameraUUID": self.camera_uuid,
             "startFrame": self.start,
             "endFrame": self.end,
+            "byFrameStep": self.step,
         })

--- a/plugins/maya/publish/extract_camera.py
+++ b/plugins/maya/publish/extract_camera.py
@@ -88,6 +88,8 @@ class ExtractCamera(PackageExtractor):
         self.add_data({
             "entryFileName": entry_file,
             "cameraUUID": self.camera_uuid,
+            "startFrame": self.start,
+            "endFrame": self.end,
         })
 
     def extract_Alembic(self):
@@ -102,6 +104,8 @@ class ExtractCamera(PackageExtractor):
         self.add_data({
             "entryFileName": entry_file,
             "cameraUUID": self.camera_uuid,
+            "startFrame": self.start,
+            "endFrame": self.end,
         })
 
     def extract_FBX(self):
@@ -117,4 +121,6 @@ class ExtractCamera(PackageExtractor):
         self.add_data({
             "entryFileName": entry_file,
             "cameraUUID": self.camera_uuid,
+            "startFrame": self.start,
+            "endFrame": self.end,
         })

--- a/plugins/maya/publish/validate_camera_bake_step.py
+++ b/plugins/maya/publish/validate_camera_bake_step.py
@@ -1,0 +1,24 @@
+import pyblish.api
+
+
+class ValidateCameraBakeStep(pyblish.api.InstancePlugin):
+    """Ensure camera bake step is a valid float
+    """
+
+    order = pyblish.api.ValidatorOrder
+    hosts = ["maya"]
+    label = "Camera Bake Step"
+    families = [
+        "reveries.camera",
+    ]
+
+    def process(self, instance):
+        bake_step = instance.data.get("bakeStep")
+        if bake_step is None:
+            self.log.warning("Using default bake step: 1.0")
+            return
+
+        self.log.info("Camera bake step: {}".format(bake_step))
+
+        if bake_step <= 0.01:
+            raise ValueError("Camera bake step can not less then 0.01")

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -652,7 +652,7 @@ def bake_to_world_space(nodes,
     return world_space_nodes
 
 
-def bake_camera(camera, startFrame, endFrame):
+def bake_camera(camera, startFrame, endFrame, step=1.0):
     """Bake camera to worldspace
 
     Returns:
@@ -678,7 +678,9 @@ def bake_camera(camera, startFrame, endFrame):
     for attr in CAMERA_SHAPE_KEYABLES:
         cmds.setAttr(shape + "." + attr, keyable=True, lock=False)
 
-    return bake_to_world_space([transform], (startFrame, endFrame))[0]
+    return bake_to_world_space([transform],
+                               (startFrame, endFrame),
+                               step=step)[0]
 
 
 def lock_transform(node, additional=None):


### PR DESCRIPTION
* Add 'bake step' control for camera publishing
    This could help resolve an issue that rendering motion blur with a camera was baked with rotation flip on +-180 degree.

* Implement shader assign fail auto fix on *renderLayer adjustment fail*