### PR TITLE
Implement 'representation root'

### DIFF
--- a/plugins/global/publish/extract_version_directory.py
+++ b/plugins/global/publish/extract_version_directory.py
@@ -41,10 +41,11 @@ class ExtractVersionDirectory(pyblish.api.InstancePlugin):
         """
         context = instance.context
         project = context.data["projectDoc"]
+        root = instance.data.get("reprRoot", avalon.api.registered_root())
 
         publish_dir_template = project["config"]["template"]["publish"]
 
-        publish_dir_key = {"root": avalon.api.registered_root(),
+        publish_dir_key = {"root": root,
                            "project": avalon.Session["AVALON_PROJECT"],
                            "silo": avalon.Session["AVALON_SILO"],
                            "asset": avalon.Session["AVALON_ASSET"],

--- a/plugins/houdini/publish/collect_cache_root.py
+++ b/plugins/houdini/publish/collect_cache_root.py
@@ -1,0 +1,19 @@
+
+import os
+import pyblish.api
+
+
+class CollectCacheRoot(pyblish.api.InstancePlugin):
+    """Inject cache storage root path into instance"""
+
+    order = pyblish.api.CollectorOrder
+    label = "Root Path For Cache"
+    hosts = ["houdini"]
+    families = [
+        "reveries.vdbcache",
+        "reveries.pointcache",
+        "reveries.standin",
+    ]
+
+    def process(self, instance):
+        instance.data["reprRoot"] = os.getenv("AVALON_CACHE_ROOT")

--- a/plugins/houdini/publish/extract_alembic.py
+++ b/plugins/houdini/publish/extract_alembic.py
@@ -46,6 +46,7 @@ class ExtractAlembic(PackageExtractor):
         self.add_data({
             "entryFileName": file_name,
         })
+        self.inject_cache_root()
 
     def extract_AlembicSeq(self):
         ropnode = self.member[0]
@@ -68,6 +69,13 @@ class ExtractAlembic(PackageExtractor):
             "endFrame": self.data["endFrame"],
             "step": self.data["step"],
         })
+        self.inject_cache_root()
+
+    def inject_cache_root(self):
+        if self.data["family"] == "reveries.pointcache":
+            self.add_data({
+                "reprRoot": self.data["reprRoot"],
+            })
 
     def render(self, ropnode, output_dir):
         import hou

--- a/plugins/houdini/publish/extract_arnold_standin.py
+++ b/plugins/houdini/publish/extract_arnold_standin.py
@@ -49,6 +49,7 @@ class ExtractArnoldStandIn(PackageExtractor):
 
         self.add_data({
             "entryFileName": file_name,
+            "reprRoot": self.data["reprRoot"],
         })
 
         if self.data.get("startFrame"):

--- a/plugins/houdini/publish/extract_vdb_cache.py
+++ b/plugins/houdini/publish/extract_vdb_cache.py
@@ -49,6 +49,7 @@ class ExtractVDBCache(PackageExtractor):
 
         self.add_data({
             "entryFileName": file_name,
+            "reprRoot": self.data["reprRoot"],
         })
 
         if self.data.get("startFrame"):

--- a/plugins/houdini/publish/validate_cache_root.py
+++ b/plugins/houdini/publish/validate_cache_root.py
@@ -1,0 +1,21 @@
+
+import pyblish.api
+
+
+class ValidateCacheRoot(pyblish.api.InstancePlugin):
+    """Ensure cache storage root path collected
+    """
+
+    order = pyblish.api.ValidatorOrder - 0.1
+    label = "Validate Cache Root"
+    hosts = ["houdini"]
+    families = [
+        "reveries.vdbcache",
+        "reveries.pointcache",
+        "reveries.standin",
+    ]
+
+    def process(self, instance):
+        cache_root = instance.data["reprRoot"]
+        assert cache_root is not None, ("Cache root not collected, "
+                                        "this is a bug.")

--- a/reveries/plugins.py
+++ b/reveries/plugins.py
@@ -296,9 +296,25 @@ class PackageLoader(object):
     """
 
     def __init__(self, context):
-        super(PackageLoader, self).__init__(context)
-        self.package_path = self.fname
-        self.fname = None  # Do not use
+        # Complete override `avalon.api.Load.__init__`
+
+        template = context["project"]["config"]["template"]["publish"]
+
+        data = {
+            key: value["name"]
+            for key, value in context.items()
+        }
+
+        representation = context["representation"]
+        repr_root = representation["data"].get("reprRoot")
+        proj_root = context["project"]["data"].get("root")
+        root = repr_root or proj_root or avalon.api.registered_root()
+
+        data["root"] = root
+        data["silo"] = context["asset"]["silo"]
+
+        package_path = template.format(**data)
+        self.package_path = package_path
 
     def file_path(self, file_name):
         return os.path.join(self.package_path, file_name)

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -368,8 +368,13 @@ def get_representation_path_(representation, parents):
     """
     version, subset, asset, project = parents
     template_publish = project["config"]["template"]["publish"]
+
+    repr_root = representation["data"].get("reprRoot")
+    proj_root = project["data"].get("root")
+    root = repr_root or proj_root or avalon.api.registered_root()
+
     return template_publish.format(**{
-        "root": avalon.api.registered_root(),
+        "root": root,
         "project": project["name"],
         "asset": asset["name"],
         "silo": asset["silo"],


### PR DESCRIPTION
Used for separated storage pipeline, like storing big cache files in different driver then normal work files.

In current use case, by defining custom root path in `AVALON_CACHE_ROOT` environment variable, which is for Houdini to publish cache files, and will be collected by this plugin: `plugins/houdini/publish/collect_cache_root.py`

Then the custom root path will be saved into representation data's `reprRoot` entry, and will be handled by the `reveries.utils.get_representation_path_` function and the `reveries.plugins.PackageLoader`.