### PR TITLE
Add VDB loader; Add .abc representation on model publish; Force commenting

### DIFF
--- a/plugins/global/publish/validate_collection_processes.py
+++ b/plugins/global/publish/validate_collection_processes.py
@@ -11,7 +11,7 @@ class ValidateCollectionProcesses(pyblish.api.ContextPlugin):
     """
 
     label = "Good Collecting"
-    order = pyblish.api.ValidatorOrder - 0.4999
+    order = pyblish.api.ValidatorOrder - 0.49999
 
     def process(self, context):
         assert all(result["success"] for result in context.data["results"]), (

--- a/plugins/global/publish/validate_comment_inputted.py
+++ b/plugins/global/publish/validate_comment_inputted.py
@@ -1,0 +1,20 @@
+import pyblish.api
+
+
+class ValidateCommentInputted(pyblish.api.ContextPlugin):
+    """One must say something before publish
+    """
+
+    label = "Validate Publish Comment"
+    order = pyblish.api.ValidatorOrder - 0.49995
+
+    def process(self, context):
+        project = context.data["projectDoc"]
+        allow_no_comment = project["data"].get("allowNoComment")
+        if allow_no_comment:
+            self.log.info("Allow no comment, skipping..")
+            return
+
+        comment = context.data["comment"].strip()
+        assert comment, "Please write a comment."
+        self.log.info("Comment provided.")

--- a/plugins/maya/load/load_arnold_standin.py
+++ b/plugins/maya/load/load_arnold_standin.py
@@ -2,8 +2,6 @@
 import os
 import avalon.api
 
-from reveries.maya import lib, pipeline
-from reveries.utils import get_representation_path_
 from reveries.maya.plugins import ReferenceLoader, ImportLoader
 
 
@@ -62,7 +60,6 @@ class ArnoldAssLoader(ImportLoader, avalon.api.Loader):
             cmds.setAttr(standin + ".useFrameExtension", True)
             cmds.connectAttr("time1.outTime", standin + ".frameNumber")
 
-        lib.lock_transform(group)
         self[:] = [standin, transform, group]
 
     def retrive(self, representation):
@@ -88,6 +85,8 @@ class ArnoldAssLoader(ImportLoader, avalon.api.Loader):
 
     def update(self, container, representation):
         import maya.cmds as cmds
+        from reveries.maya import pipeline
+        from reveries.utils import get_representation_path_
 
         members = cmds.sets(container["objectName"], query=True)
         standin = next(iter(cmds.ls(members, type="aiStandIn")), None)

--- a/plugins/maya/load/load_arnold_volume.py
+++ b/plugins/maya/load/load_arnold_volume.py
@@ -1,0 +1,74 @@
+
+import avalon.api
+from reveries.maya.plugins import ImportLoader
+
+
+class ArnoldVolumeLoader(ImportLoader, avalon.api.Loader):
+
+    label = "Load Arnold Volume"
+    order = -10
+    icon = "cloud"
+    color = "orange"
+
+    hosts = ["maya"]
+
+    families = [
+        "reveries.vdbcache",
+    ]
+
+    representations = [
+        "VDB",
+    ]
+
+    def process_import(self, context, name, namespace, group, options):
+        from maya import cmds
+        from reveries.maya import capsule, arnold
+
+        representation = context["representation"]
+        use_sequence = "startFrame" in representation["data"]
+        entry_path = self.file_path(representation)
+
+        with capsule.namespaced(namespace):
+            volume = arnold.create_volume(entry_path)
+            transform = cmds.listRelatives(volume, parent=True)[0]
+            group = cmds.group(transform, name=group, world=True)
+
+        if use_sequence:
+            cmds.setAttr(volume + ".useFrameExtension", True)
+
+        self[:] = [volume, transform, group]
+
+    def update(self, container, representation):
+        import maya.cmds as cmds
+        from reveries.maya import pipeline
+        from reveries.utils import get_representation_path_
+
+        members = cmds.sets(container["objectName"], query=True)
+        volume = next(iter(cmds.ls(members, type="aiVolume")), None)
+
+        if not volume:
+            raise Exception("No Arnold Volume node, this is a bug.")
+
+        parents = avalon.io.parenthood(representation)
+        self.package_path = get_representation_path_(representation, parents)
+
+        use_sequence = "startFrame" in representation["data"]
+        entry_path = self.file_path(representation)
+
+        if not entry_path.endswith(".vdb"):
+            raise Exception("Not a VDB file, this is a bug: "
+                            "%s" % entry_path)
+
+        cmds.setAttr(volume + ".filename", entry_path, type="string")
+        cmds.setAttr(volume + ".useFrameExtension", use_sequence)
+
+        # Update container
+        version, subset, asset, _ = parents
+        pipeline.update_container(container,
+                                  asset,
+                                  subset,
+                                  version,
+                                  representation)
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -5,7 +5,7 @@ import pyblish.api
 
 import maya.cmds as cmds
 
-from reveries.maya import capsule, io, utils
+from reveries.maya import capsule, io, utils, lib
 from reveries.plugins import PackageExtractor
 
 
@@ -25,6 +25,7 @@ class ExtractModel(PackageExtractor):
 
     representations = [
         "mayaBinary",
+        "Alembic",
         "GPUCache",
     ]
 
@@ -117,6 +118,34 @@ class ExtractModel(PackageExtractor):
         frame = cmds.currentTime(query=True)
         io.export_gpu(cache_path, frame, frame)
         io.wrap_gpu(entry_path, [(cache_file, self.data["subset"])])
+
+        self.add_data({
+            "entryFileName": entry_file,
+        })
+
+    def extract_Alembic(self):
+        entry_file = self.file_name("abc")
+        package_path = self.create_package()
+        entry_path = os.path.join(package_path, entry_file)
+
+        cmds.select(self.member, noExpand=True)
+
+        frame = cmds.currentTime(query=True)
+        io.export_alembic(
+            entry_path,
+            frame,
+            frame,
+            selection=True,
+            renderableOnly=True,
+            writeCreases=True,
+            worldSpace=True,
+            attr=[
+                lib.AVALON_ID_ATTR_LONG,
+            ],
+            attrPrefix=[
+                "ai",  # Write out Arnold attributes
+            ],
+        )
 
         self.add_data({
             "entryFileName": entry_file,

--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -5,7 +5,7 @@ import pyblish.api
 
 import maya.cmds as cmds
 
-from reveries.maya import capsule, utils
+from reveries.maya import capsule, io, utils
 from reveries.plugins import PackageExtractor
 
 
@@ -25,6 +25,7 @@ class ExtractModel(PackageExtractor):
 
     representations = [
         "mayaBinary",
+        "GPUCache",
     ]
 
     def extract(self):
@@ -105,3 +106,18 @@ class ExtractModel(PackageExtractor):
             name=self.data["subset"],
             path=entry_path)
         )
+
+    def extract_GPUCache(self):
+        entry_file = self.file_name("ma")
+        cache_file = self.file_name("abc")
+        package_path = self.create_package()
+        entry_path = os.path.join(package_path, entry_file)
+        cache_path = os.path.join(package_path, cache_file)
+
+        frame = cmds.currentTime(query=True)
+        io.export_gpu(cache_path, frame, frame)
+        io.wrap_gpu(entry_path, [(cache_file, self.data["subset"])])
+
+        self.add_data({
+            "entryFileName": entry_file,
+        })

--- a/reveries/maya/arnold/__init__.py
+++ b/reveries/maya/arnold/__init__.py
@@ -4,6 +4,7 @@ from .utils import (
     get_arnold_aov_nodes,
     get_arnold_aov_names,
     create_standin,
+    create_volume,
 )
 
 # Requirement, obviously
@@ -14,4 +15,5 @@ __all__ = (
     "get_arnold_aov_nodes",
     "get_arnold_aov_names",
     "create_standin",
+    "create_volume",
 )

--- a/reveries/maya/arnold/utils.py
+++ b/reveries/maya/arnold/utils.py
@@ -110,3 +110,13 @@ def apply_ai_attrs(relationships, namespace=None, target_namespaces=None):
 def create_standin(path):
     import mtoa
     return mtoa.core.createStandIn(path)
+
+
+def create_volume(path):
+    import mtoa
+    before = set(cmds.ls(type="aiVolume"))
+    mtoa.core.createVolume()  # Returns nothing...
+    after = set(cmds.ls(type="aiVolume"))
+    new_node = (after - before).pop()
+    cmds.setAttr(new_node + ".filename", path, type="string")
+    return new_node

--- a/reveries/maya/interactive.py
+++ b/reveries/maya/interactive.py
@@ -51,10 +51,10 @@ def wipe_all_namespaces():
 def apply_avalon_uuid(*args):
     # (TODO): Implement GUI
     nodes = (set(cmds.ls(type="geometryShape", long=True)) -
-             set(cmds.ls(long=True, readOnly=True)) -
-             set(cmds.ls(long=True, lockedNodes=True)))
+             set(cmds.ls(readOnly=True, long=True)) -
+             set(cmds.ls(lockedNodes=True, long=True)))
 
-    transforms = cmds.listRelatives(list(nodes), parent=True) or list()
+    transforms = cmds.listRelatives(list(nodes), parent=True, long=True) or []
 
     # Add unique identifiers
     for node in transforms:


### PR DESCRIPTION
### VDB Loader

For Maya to load `.vdb` with Arnold's `aiVolume`.

### Add Alembic on model publish

Not only `mayaBinary`, will also extract `Alembic` and `GPU cache` on model publish. This is for the set-dressing + Houdini.

### Force commenting

One must input something into comment field when publish, unless the project config has `allowNoComment` entry set to `True`.