### PR TITLE
Fix texture publishing and other major improvements

### DIFF
--- a/plugins/maya/inventory/action_update_look_preserve_edit.py
+++ b/plugins/maya/inventory/action_update_look_preserve_edit.py
@@ -1,0 +1,27 @@
+
+import avalon.api
+
+from avalon.tools.sceneinventory import app
+
+
+class UpdateLookPreserveEdit(avalon.api.InventoryAction):
+
+    label = "Update Preserve Edit"
+    icon = "pencil"
+    color = "#ffbb66"
+    order = 200
+
+    @staticmethod
+    def is_compatible(container):
+        return container.get("loader") == "LookLoader"
+
+    def process(self, containers):
+        items = list()
+
+        for container in containers:
+            if self.is_compatible(container):
+                container["_preserveRefEdit"] = True
+
+            items.append(container)
+
+        app.window.view.show_version_dialog(items)

--- a/plugins/maya/load/load_look.py
+++ b/plugins/maya/load/load_look.py
@@ -64,6 +64,10 @@ class LookLoader(ReferenceLoader, avalon.api.Loader):
         from reveries.maya import lib
         from avalon.maya.pipeline import AVALON_CONTAINER_ID, parse_container
 
+        # Flag `_preserveRefEdit` from `container` is a workaround
+        # should coming from `options`
+        preserve_edit = container.pop("_preserveRefEdit", False)
+
         nodes = cmds.sets(container["objectName"], query=True)
         shaders = cmds.ls(nodes, type="shadingEngine")
         shaded = cmds.ls(cmds.sets(shaders, query=True), long=True)
@@ -124,6 +128,8 @@ class LookLoader(ReferenceLoader, avalon.api.Loader):
         uuid = cmds.ls(container["objectName"], uuid=True)
 
         # Update
+        if not preserve_edit:
+            container["_dropRefEdit"] = True
         super(LookLoader, self).update(container, representation)
 
         if not shaded_subsets:

--- a/plugins/maya/publish/avalon_scene_ready.py
+++ b/plugins/maya/publish/avalon_scene_ready.py
@@ -1,0 +1,26 @@
+
+import pyblish.api
+
+
+class AvalonSceneReady(pyblish.api.ContextPlugin):
+    """Define current scene in ready state
+
+    Collecte current undo count for later validation.
+
+    """
+
+    order = pyblish.api.CollectorOrder + 0.49999
+    label = "Scene Ready"
+    hosts = ["maya"]
+
+    def process(self, context):
+        from maya import cmds
+        from reveries.maya import capsule
+
+        # Ensure undo queue is active
+        cmds.undoInfo(state=True)
+
+        with capsule.OutputDeque() as undo_list:
+            cmds.undoInfo(query=True, printQueue=True)
+
+        context.data["_undoCount"] = len(undo_list)

--- a/plugins/maya/publish/avalon_scene_ready_check.py
+++ b/plugins/maya/publish/avalon_scene_ready_check.py
@@ -10,7 +10,7 @@ class AvalonCheckSceneReady(pyblish.api.ContextPlugin):
 
     """
 
-    order = pyblish.api.ValidatorOrder - 0.499999
+    order = pyblish.api.ValidatorOrder - 0.49998
     label = "Is Scene Ready"
     hosts = ["maya"]
 
@@ -21,13 +21,16 @@ class AvalonCheckSceneReady(pyblish.api.ContextPlugin):
         if not cmds.undoInfo(query=True, state=True):
             raise Exception("Undo queue is not open, please reset.")
 
+        undo_count = context.data["_undoCount"]
+        # self.log.debug(undo_count)
+
         with capsule.OutputDeque(format=lambda l: l.split(": ", 1)[-1].strip(),
-                                 skip=context.data["_undoCount"],
+                                 skip=undo_count,
                                  ) as undo_list:
             cmds.undoInfo(query=True, printQueue=True)
 
         while undo_list:
-            history = undo_list.popleft()
+            history = undo_list.pop()
             # self.log.debug(history)
 
             if history.startswith("select"):

--- a/plugins/maya/publish/avalon_scene_ready_check.py
+++ b/plugins/maya/publish/avalon_scene_ready_check.py
@@ -1,0 +1,37 @@
+
+import pyblish.api
+
+
+class AvalonCheckSceneReady(pyblish.api.ContextPlugin):
+    """Validate current scene still fit the definition of *ready*
+
+    By checking new undo commands in undo queue after collecting, and consider
+    scene is not ready if there are any non-select command.
+
+    """
+
+    order = pyblish.api.ValidatorOrder - 0.499999
+    label = "Is Scene Ready"
+    hosts = ["maya"]
+
+    def process(self, context):
+        from maya import cmds
+        from reveries.maya import capsule
+
+        if not cmds.undoInfo(query=True, state=True):
+            raise Exception("Undo queue is not open, please reset.")
+
+        with capsule.OutputDeque(format=lambda l: l.split(": ", 1)[-1].strip(),
+                                 skip=context.data["_undoCount"],
+                                 ) as undo_list:
+            cmds.undoInfo(query=True, printQueue=True)
+
+        while undo_list:
+            history = undo_list.popleft()
+            # self.log.debug(history)
+
+            if history.startswith("select"):
+                continue
+
+            raise Exception("Scene has been modified, no longer in *ready* "
+                            "state. Please reset.")

--- a/plugins/maya/publish/collect_lightSet.py
+++ b/plugins/maya/publish/collect_lightSet.py
@@ -14,11 +14,12 @@ def create_texture_subset_from_lightSet(instance, textures):
 
     data = {"useTxMaps": True}
 
-    plugins.create_dependency_instance(instance,
-                                       subset,
-                                       family,
-                                       textures,
-                                       data=data)
+    child = plugins.create_dependency_instance(instance,
+                                               subset,
+                                               family,
+                                               textures,
+                                               data=data)
+    instance.data["textureInstance"] = child
 
 
 class CollectLightSet(pyblish.api.InstancePlugin):

--- a/plugins/maya/publish/collect_look.py
+++ b/plugins/maya/publish/collect_look.py
@@ -39,13 +39,19 @@ class CollectLook(pyblish.api.InstancePlugin):
         shaders = cmds.listConnections(surfaces, type="shadingEngine")
         shaders = list(set(shaders))
         try:
-            _history = cmds.listHistory(shaders)
+            # (NOTE): The flag `pruneDagObjects` will also filter out
+            #         `place3dTexture` type node.
+            # (NOTE): Without flag `allConnections`, upstream nodes before
+            #         `aiColorCorrect` may not be tracked if only `outAlpha`
+            #         is connected to downstream node.
+            #         This might be a bug of Arnold since other Maya node
+            #         does not have this issue, not fully tested so not
+            #         sure. MtoA version: 3.1.2.1
+            _history = cmds.listHistory(shaders, allConnections=True)
             _history = list(set(_history))
         except RuntimeError:
             _history = []  # Found no items to list the history for.
         upstream_nodes = cmds.ls(_history, long=True)
-        # (NOTE): The flag `pruneDagObjects` will also filter out
-        # `place3dTexture` type node.
 
         # Remove unwanted types
         unwanted_types = ("groupId", "groupParts", "surfaceShape")

--- a/plugins/maya/publish/collect_look.py
+++ b/plugins/maya/publish/collect_look.py
@@ -14,11 +14,12 @@ def create_texture_subset_from_look(instance, textures):
 
     data = {"useTxMaps": True}
 
-    plugins.create_dependency_instance(instance,
-                                       subset,
-                                       family,
-                                       textures,
-                                       data=data)
+    child = plugins.create_dependency_instance(instance,
+                                               subset,
+                                               family,
+                                               textures,
+                                               data=data)
+    instance.data["textureInstance"] = child
 
 
 class CollectLook(pyblish.api.InstancePlugin):
@@ -34,6 +35,9 @@ class CollectLook(pyblish.api.InstancePlugin):
         surfaces = cmds.ls(instance,
                            noIntermediate=True,
                            type="surfaceShape")
+        if not surfaces:
+            raise Exception("No surface collected, this should not happen. "
+                            "Possible empty group ?")
 
         # Collect shading networks
         shaders = cmds.listConnections(surfaces, type="shadingEngine")

--- a/plugins/maya/publish/collect_texture_files.py
+++ b/plugins/maya/publish/collect_texture_files.py
@@ -19,69 +19,12 @@ class CollectTextureFiles(pyblish.api.InstancePlugin):
     ]
 
     def process(self, instance):
-        import os
         from maya import cmds
-        from maya.app.general.fileTexturePathResolver import (
-            getFilePatternString,
-            findAllFilesForPattern,
-        )
+        from reveries.maya import lib
 
-        file_data = list()
-        file_count = 0
         file_nodes = instance.data.get("fileNodes",
                                        cmds.ls(instance, type="file"))
-
-        for file_node in file_nodes:
-
-            color_space = cmds.getAttr(file_node + ".colorSpace")
-            tiling_mode = cmds.getAttr(file_node + ".uvTilingMode")
-            is_sequence = cmds.getAttr(file_node + ".useFrameExtension")
-            file_path = cmds.getAttr(file_node + ".fileTextureName",
-                                     expandEnvironmentVariables=True)
-
-            file_path = file_path.replace("\\", "/")
-            dir_name = os.path.dirname(file_path)
-
-            if not (is_sequence or tiling_mode):
-                # (NOTE) If no sequence and no tiling, skip regex parsing
-                #        to avoid potential not-regex-friendly file name which
-                #        may lead to incorrect result.
-                pattern = file_path
-                all_files = [os.path.basename(pattern)]
-            else:
-                # (NOTE) When UV tiliing is enabled, if file name contains
-                #        characters like `[]`, which possible from Photoshop,
-                #        will make regex parse file name incorrectly.
-                pattern = getFilePatternString(file_path,
-                                               is_sequence,
-                                               tiling_mode)
-                all_files = [
-                    os.path.basename(fpath) for fpath in
-                    findAllFilesForPattern(pattern, frameNumber=None)
-                ]
-
-            if not all_files:
-                self.log.error("%s file not exists." % file_node)
-                continue
-
-            fpattern = os.path.basename(pattern)
-
-            if len(all_files) > 1:
-                # If it's a sequence, include the dir name as the prefix
-                # of the file pattern
-                dir_name, seq_dir = os.path.split(dir_name)
-                fpattern = seq_dir + "/" + fpattern
-                all_files = [seq_dir + "/" + file for file in all_files]
-
-            file_data.append({
-                "node": file_node,
-                "fpattern": fpattern,
-                "colorSpace": color_space,
-                "dir": dir_name,
-                "fnames": all_files,
-            })
-
-            file_count += len(all_files)
+        file_count, file_data = lib.profiling_file_nodes(file_nodes)
 
         instance.data["fileData"] = file_data
 

--- a/plugins/maya/publish/extract_arnold_standin.py
+++ b/plugins/maya/publish/extract_arnold_standin.py
@@ -60,11 +60,9 @@ class ExtractArnoldStandIn(PackageExtractor):
             capsule.evaluation("off"),
             capsule.maintained_selection(),
             capsule.ref_edit_unlock(),
-            # (NOTE) Force color space unlocked
-            #        Previously we used to lock color space in case
-            #        forgot to check it after changing file path.
+            # (NOTE) Ensure attribute unlock
             capsule.attribute_states(file_node_attrs.keys(), lock=False),
-            # Change to .tx path
+            # Change to environment var embedded path
             capsule.attribute_values(file_node_attrs),
         ):
             cmds.select(self.member, replace=True)

--- a/plugins/maya/publish/extract_lightSet.py
+++ b/plugins/maya/publish/extract_lightSet.py
@@ -35,7 +35,11 @@ class ExtractLightSet(PackageExtractor):
         self.log.info("Extracting lights..")
 
         # From texture extractor
-        file_node_attrs = self.context.data.get("fileNodeAttrs", dict())
+        texture = self.data.get("textureInstance")
+        if texture is not None:
+            file_node_attrs = texture.data.get("fileNodeAttrs", dict())
+        else:
+            file_node_attrs = dict()
 
         with contextlib.nested(
             maya.maintained_selection(),

--- a/plugins/maya/publish/extract_look.py
+++ b/plugins/maya/publish/extract_look.py
@@ -50,7 +50,11 @@ class ExtractLook(PackageExtractor):
 
         self.log.info("Extracting shaders..")
 
-        file_node_attrs = self.data.get("fileNodeAttrs", dict())
+        texture = self.data.get("textureInstance")
+        if texture is not None:
+            file_node_attrs = texture.data.get("fileNodeAttrs", dict())
+        else:
+            file_node_attrs = dict()
 
         with contextlib.nested(
             maya.maintained_selection(),

--- a/plugins/maya/publish/extract_look.py
+++ b/plugins/maya/publish/extract_look.py
@@ -50,10 +50,14 @@ class ExtractLook(PackageExtractor):
 
         self.log.info("Extracting shaders..")
 
-        file_node_attrs = self.context.data.get("fileNodeAttrs", dict())
+        file_node_attrs = self.data.get("fileNodeAttrs", dict())
 
         with contextlib.nested(
             maya.maintained_selection(),
+            capsule.ref_edit_unlock(),
+            # (NOTE) Ensure attribute unlock
+            capsule.attribute_states(file_node_attrs.keys(), lock=False),
+            # Change to published path
             capsule.attribute_values(file_node_attrs),
             capsule.no_refresh(),
         ):

--- a/plugins/maya/publish/extract_texture.py
+++ b/plugins/maya/publish/extract_texture.py
@@ -37,8 +37,8 @@ class ExtractTexture(PackageExtractor):
 
         # For storing calculated published file path for look or lightSet
         # extractors to update file path.
-        if "fileNodeAttrs" not in self.context.data:
-            self.context.data["fileNodeAttrs"] = OrderedDict()
+        if "fileNodeAttrs" not in self.data:
+            self.data["fileNodeAttrs"] = OrderedDict()
 
         # Extract textures
         #

--- a/plugins/maya/publish/extract_texture.py
+++ b/plugins/maya/publish/extract_texture.py
@@ -103,16 +103,14 @@ class ExtractTexture(PackageExtractor):
             for ver_data, tmp_data in versioned_data:
 
                 previous_files = tmp_data["pathMap"]
-                previous_txs = tmp_data["pathMapTx"]
 
                 all_files = list()
                 for file, abs_path in data["pathMap"].items():
-                    if not (file in previous_files or file in previous_txs):
+                    if file not in previous_files:
                         # Possible different file pattern
                         break  # Try previous version
 
-                    _previous_tx = previous_txs.get(file)
-                    abs_previous = previous_files.get(file, _previous_tx)
+                    abs_previous = previous_files.get(file, "")
 
                     if not os.path.isfile(abs_previous):
                         # Previous file not exists (should not happen)

--- a/plugins/maya/publish/extract_texture.py
+++ b/plugins/maya/publish/extract_texture.py
@@ -8,7 +8,7 @@ import avalon.io
 
 from reveries import utils, lib
 from reveries.plugins import PackageExtractor, skip_stage
-# from reveries.maya.plugins import env_embedded_path
+from reveries.maya.plugins import env_embedded_path
 
 
 def to_tx(path):
@@ -76,7 +76,7 @@ class ExtractTexture(PackageExtractor):
     def extract_TexturePack(self):
 
         package_path = self.create_package()
-        # package_path = env_embedded_path(package_path)
+        package_path = env_embedded_path(package_path)
 
         # For storing calculated published file path for look or lightSet
         # extractors to update file path.
@@ -173,7 +173,7 @@ class ExtractTexture(PackageExtractor):
                     # Version matched, consider as same file
                     head_file = sorted(all_files)[0]
                     resolved_path = abs_previous[:-len(file)] + head_file
-                    # resolved_path = env_embedded_path(resolved_path)
+                    resolved_path = env_embedded_path(resolved_path)
                     self.update_file_node_attrs(file_nodes,
                                                 resolved_path,
                                                 current_color_space)

--- a/plugins/maya/publish/extract_texture.py
+++ b/plugins/maya/publish/extract_texture.py
@@ -221,24 +221,24 @@ class ExtractTexture(PackageExtractor):
         self.add_data({"fileInventory": file_inventory})
 
     def update_file_node_attrs(self, file_nodes, path, color_space):
-        from maya import cmds
-
-        """Deprecated, .tx map may crash viewport 2.0 and hypershade material window
-        if self.use_tx:
-            # Force downstream to use .tx map
-            path = to_tx(path)
-        """
+        from reveries.maya import lib
 
         for node in file_nodes:
             attr = node + ".fileTextureName"
-            self.context.data["fileNodeAttrs"][attr] = path
+            self.data["fileNodeAttrs"][attr] = path
             # Preserve color space values (force value after filepath change)
             # This will also trigger in the same order at end of context to
             # ensure after context it's still the original value.
             attr = node + ".colorSpace"
-            self.context.data["fileNodeAttrs"][attr] = color_space
+            self.data["fileNodeAttrs"][attr] = color_space
 
-            # (NOTE) Force color space unlocked
-            #        Previously we used to lock color space in case
-            #        forgot to check it after changing file path.
-            cmds.setAttr(attr, lock=False)
+            attr = node + ".ignoreColorSpaceFileRules"
+            self.data["fileNodeAttrs"][attr] = True
+
+            if lib.hasAttr(node, "aiAutoTx"):
+                # Although we ensured the tx update, but the file modification
+                # time still may loose during file transfer and trigger another
+                # tx update later on. So we force disable it on each published
+                # file node.
+                attr = node + ".aiAutoTx"
+                self.data["fileNodeAttrs"][attr] = False

--- a/plugins/maya/publish/extract_txMap_update.py
+++ b/plugins/maya/publish/extract_txMap_update.py
@@ -46,14 +46,15 @@ class ExtractTxMapUpdate(pyblish.api.InstancePlugin):
         self.log.info("Ensuring all .tx files updated..")
 
         core.createOptions()
-        recorder = list()
 
-        with capsule.record_history(recorder):
+        with capsule.OutputDeque() as recorder:
             # (NOTE) This was from the Arnold's utilities menu tool
             #        "Update TX Files". The command will not re-create .tx file
             #        if updated.
             cmds.arnoldUpdateTx()
 
         # Check history for update output
-        if any(line.startswith("# Error:") for line in recorder):
-            raise Exception("Error occurred during tx map update.")
+        while recorder:
+            log = recorder.pop()
+            if "could not be updated" in log:
+                raise Exception("Error occurred during tx map update.")

--- a/plugins/maya/publish/extract_txMap_update.py
+++ b/plugins/maya/publish/extract_txMap_update.py
@@ -34,6 +34,7 @@ class ExtractTxMapUpdate(pyblish.api.InstancePlugin):
 
     def update_tx(self):
         from maya import cmds
+        from reveries.maya import capsule
 
         if cmds.pluginInfo("mtoa", query=True, loaded=True):
             import mtoa.core as core
@@ -43,8 +44,16 @@ class ExtractTxMapUpdate(pyblish.api.InstancePlugin):
             return
 
         self.log.info("Ensuring all .tx files updated..")
-        # (NOTE) This was from the Arnold's utilities menu tool
-        #        "Update TX Files". The command will not re-create .tx file
-        #        if updated.
+
         core.createOptions()
-        cmds.arnoldUpdateTx()
+        recorder = list()
+
+        with capsule.record_history(recorder):
+            # (NOTE) This was from the Arnold's utilities menu tool
+            #        "Update TX Files". The command will not re-create .tx file
+            #        if updated.
+            cmds.arnoldUpdateTx()
+
+        # Check history for update output
+        if any(line.startswith("# Error:") for line in recorder):
+            raise Exception("Error occurred during tx map update.")

--- a/plugins/maya/publish/validate_texture_no_direct_tx.py
+++ b/plugins/maya/publish/validate_texture_no_direct_tx.py
@@ -1,0 +1,40 @@
+
+import pyblish.api
+from reveries.maya.plugins import MayaSelectInvalidInstanceAction
+
+
+class ValidateTextureNoDirectTX(pyblish.api.InstancePlugin):
+    """Directly use TX map in file node is not allowed
+
+    (NOTE): If the original image is missing.. change the file extension
+            from `.tx` to `.tif` then edit or save as.
+
+    """
+
+    order = pyblish.api.ValidatorOrder
+    label = "No Direct TX Used"
+    hosts = ["maya"]
+    families = [
+        "reveries.texture",
+        "reveries.standin",
+    ]
+    actions = [
+        pyblish.api.Category("Select"),
+        MayaSelectInvalidInstanceAction,
+    ]
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise Exception("Do NOT use TX map directly.")
+
+    @classmethod
+    def get_invalid(cls, instance):
+        invalid = list()
+        for data in instance.data.get("fileData", []):
+            node = data["node"]
+            fpattern = data["fpattern"]
+            if fpattern.endswith(".tx"):
+                invalid.append(node)
+
+        return invalid

--- a/plugins/maya/publish/validate_texture_txMap_created.py
+++ b/plugins/maya/publish/validate_texture_txMap_created.py
@@ -1,10 +1,10 @@
 
 import os
 import pyblish.api
-from reveries.maya.plugins import MayaSelectInvalidContextAction
+from reveries.maya.plugins import MayaSelectInvalidInstanceAction
 
 
-class ValidateTxMapCreated(pyblish.api.InstancePlugin):
+class ValidateTextureTxMapCreated(pyblish.api.InstancePlugin):
     """Ensure all texture file have .tx map created
 
     If you got error from this validation, please use Arnold's 'Tx Manager'
@@ -30,7 +30,7 @@ class ValidateTxMapCreated(pyblish.api.InstancePlugin):
     ]
     actions = [
         pyblish.api.Category("Select"),
-        MayaSelectInvalidContextAction,
+        MayaSelectInvalidInstanceAction,
     ]
 
     def process(self, instance):

--- a/reveries/maya/callbacks.py
+++ b/reveries/maya/callbacks.py
@@ -101,11 +101,18 @@ def on_open(_):
                       "callbacks._outliner_hide_set_member()")
 
     # (Medicine)
+    #
     maya_utils.drop_interface()
-    maya_utils.fix_texture_file_nodes()
+    # Only fix containerized file nodes
+    nodes = set()
+    for container in maya.ls():
+        nodes.update(cmds.ls(cmds.sets(container["objectName"], query=True),
+                             type="file"))
+    maya_utils.fix_texture_file_nodes(list(nodes))
 
+    # For log reading and debug
+    #
     if cmds.about(batch=True):
-        # For log reading and debug
         print("Maya API version: %s" % cmds.about(api=True))
         if cmds.pluginInfo("mtoa", q=True, loaded=True):
             version = cmds.pluginInfo("mtoa", q=True, version=True)

--- a/reveries/maya/callbacks.py
+++ b/reveries/maya/callbacks.py
@@ -1,6 +1,7 @@
 
 import os
 import importlib
+from maya.api import OpenMaya as om  # API 2.0
 from maya import cmds, OpenMaya
 from avalon import maya, api as avalon
 
@@ -72,6 +73,13 @@ def on_init(_):
         before_import_reference
     )
 
+    avalon.logger.info("Installing callbacks on reference..")
+
+    # API 2.0
+    om.MSceneMessage.addCheckFileCallback(
+        om.MSceneMessage.kBeforeCreateReferenceCheck,
+        before_create_reference
+    )
     cmds.evalDeferred("from reveries.maya import callbacks;"
                       "callbacks._outliner_hide_set_member()")
 
@@ -92,7 +100,16 @@ def on_open(_):
     cmds.evalDeferred("from reveries.maya import callbacks;"
                       "callbacks._outliner_hide_set_member()")
 
+    # (Medicine)
     maya_utils.drop_interface()
+    maya_utils.fix_texture_file_nodes()
+
+    if cmds.about(batch=True):
+        # For log reading and debug
+        print("Maya API version: %s" % cmds.about(api=True))
+        if cmds.pluginInfo("mtoa", q=True, loaded=True):
+            version = cmds.pluginInfo("mtoa", q=True, version=True)
+            print("MtoA version: %s" % version)
 
 
 def on_save(_):
@@ -155,3 +172,20 @@ def on_import_reference(_):
     imported_nodes = list(before_nodes - after_nodes)
     maya_utils.update_id_verifiers(imported_nodes)
     _nodes["_"] = None
+
+
+def before_create_reference(reference_node,
+                            referenced_file,
+                            clientData=None):
+    """Using API 2.0"""
+    avalon.logger.info("Running callback before create reference..")
+
+    # (Medicine) Patch bad env var embedded path.
+    bug = "$AVALON_PROJECTS$AVALON_PROJECT"
+    fix = "$AVALON_PROJECTS/$AVALON_PROJECT"
+    path = reference_node.rawFullName()
+    if path.startswith(bug):
+        path = path.replace(bug, fix)
+        reference_node.setRawFullName(path)
+
+    return True

--- a/reveries/maya/capsule.py
+++ b/reveries/maya/capsule.py
@@ -624,7 +624,7 @@ class OutputDeque(collections.deque):
 
         def catch_output(msg, *args):
             self.__count += 1
-            if self.__count < self.skip:
+            if self.__count <= self.skip:
                 return
 
             formatted = self.format(msg)

--- a/reveries/maya/capsule.py
+++ b/reveries/maya/capsule.py
@@ -1,6 +1,9 @@
 
 import os
 import contextlib
+import collections
+
+import maya.OpenMaya as om
 from maya import cmds, mel
 from avalon.vendor.six import string_types
 from . import lib
@@ -618,3 +621,51 @@ def record_history(recorder):
             recorder[:] = list(history.readlines())
 
         os.remove(tmp)
+
+
+class OutputDeque(collections.deque):
+    """Record Maya command output during the context
+
+    A context manager, subclass of `collections.deque`.
+    Maya command output will be added into this deque during the context.
+
+    Args:
+        ignore_empty (bool, optional): Whether to ignore empty formatted
+            output line. Default True.
+        format (callable, optional): Function for formatting output.
+        skip (int, optional): Skip first numbers of outputs.
+        max (int, optional): Max length of the deque.
+
+    """
+
+    def __init__(self,
+                 ignore_empty=True,
+                 format=None,
+                 skip=0,
+                 max=None):
+        self.ignore_empty = ignore_empty
+        self.format = format or (lambda line: line)
+        self.skip = skip
+
+        self.__callback_id = None
+        self.__count = 0
+        super(OutputDeque, self).__init__(maxlen=max)
+
+    def __enter__(self):
+        add_callback = om.MCommandMessage.addCommandOutputCallback
+
+        def catch_output(msg, *args):
+            self.__count += 1
+            if self.__count < self.skip:
+                return
+
+            formatted = self.format(msg)
+            if formatted or not self.ignore_empty:
+                self.append(formatted)
+
+        self.__callback_id = add_callback(catch_output)
+
+        return self
+
+    def __exit__(self, *args):
+        om.MCommandMessage.removeCallback(self.__callback_id)

--- a/reveries/maya/capsule.py
+++ b/reveries/maya/capsule.py
@@ -1,5 +1,4 @@
 
-import os
 import contextlib
 import collections
 
@@ -7,7 +6,6 @@ import maya.OpenMaya as om
 from maya import cmds, mel
 from avalon.vendor.six import string_types
 from . import lib
-from .. import utils
 
 
 @contextlib.contextmanager
@@ -591,36 +589,6 @@ def attribute_values(attr_values):
                 cmds.setAttr(attr, "", type="string")
             else:
                 cmds.setAttr(attr, value)
-
-
-@contextlib.contextmanager
-def record_history(recorder):
-    """Record Maya logs during the context
-
-    Enable Maya Script Editor's write-history feature and read history file
-    lines to a list on context exit.
-
-    Args:
-        recorder (list): An empty list for storing logs on context exit
-
-    """
-    tmp = utils.temp_dir(prefix="mayalog_") + "/mayalog.txt"
-
-    try:
-        cmds.scriptEditorInfo(historyFilename=tmp, writeHistory=True)
-        yield
-
-    finally:
-        cmds.scriptEditorInfo(writeHistory=False)
-
-        if not os.path.isfile(tmp):
-            cmds.warning("History file not exists, this is a bug.")
-            return
-
-        with open(tmp, "r") as history:
-            recorder[:] = list(history.readlines())
-
-        os.remove(tmp)
 
 
 class OutputDeque(collections.deque):

--- a/reveries/maya/capsule.py
+++ b/reveries/maya/capsule.py
@@ -1,7 +1,10 @@
+
+import os
 import contextlib
 from maya import cmds, mel
 from avalon.vendor.six import string_types
 from . import lib
+from .. import utils
 
 
 @contextlib.contextmanager
@@ -585,3 +588,33 @@ def attribute_values(attr_values):
                 cmds.setAttr(attr, "", type="string")
             else:
                 cmds.setAttr(attr, value)
+
+
+@contextlib.contextmanager
+def record_history(recorder):
+    """Record Maya logs during the context
+
+    Enable Maya Script Editor's write-history feature and read history file
+    lines to a list on context exit.
+
+    Args:
+        recorder (list): An empty list for storing logs on context exit
+
+    """
+    tmp = utils.temp_dir(prefix="mayalog_") + "/mayalog.txt"
+
+    try:
+        cmds.scriptEditorInfo(historyFilename=tmp, writeHistory=True)
+        yield
+
+    finally:
+        cmds.scriptEditorInfo(writeHistory=False)
+
+        if not os.path.isfile(tmp):
+            cmds.warning("History file not exists, this is a bug.")
+            return
+
+        with open(tmp, "r") as history:
+            recorder[:] = list(history.readlines())
+
+        os.remove(tmp)

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -155,6 +155,10 @@ class ReferenceLoader(MayaBaseLoader):
     def update(self, container, representation):
         from maya import cmds
 
+        # Flag `_dropRefEdit` from `container` is a workaround
+        # should coming from `options`
+        drop_edit = container.pop("_dropRefEdit", False)
+
         node = container["objectName"]
 
         # Get reference node from container
@@ -177,6 +181,10 @@ class ReferenceLoader(MayaBaseLoader):
 
         if file_type not in ("mayaBinary", "Alembic"):
             file_type = "mayaAscii"
+
+        if drop_edit:
+            cmds.file(unloadReference=reference_node)
+            cmds.file(cleanReference=reference_node, editCommand="setAttr")
 
         cmds.file(entry_path,
                   loadReference=reference_node,

--- a/reveries/maya/utils.py
+++ b/reveries/maya/utils.py
@@ -31,6 +31,43 @@ from . import lib, capsule
 log = logging.getLogger(__name__)
 
 
+def texture_path_expand(nodes=lib._no_val):
+    """Expand file nodes' file path that has environment variable embedded
+
+    Args:
+        nodes (list, optional): List of nodes, process all nodes if not
+                                provided.
+
+    """
+    args = (nodes, ) if nodes is not lib._no_val else ()
+
+    for node in cmds.ls(*args, type="file"):
+        attr = node + ".fileTextureName"
+        path = cmds.getAttr(attr, expandEnvironmentVariables=True)
+        cmds.setAttr(attr, path, type="string")
+
+
+def texture_path_embed(nodes=lib._no_val):
+    """Embed environment variables into file nodes' file path
+
+    Environment variables that will be embedded:
+        * AVALON_PROJECTS
+        * AVALON_PROJECT
+
+    Args:
+        nodes (list, optional): List of nodes, process all nodes if not
+                                provided.
+
+    """
+    args = (nodes, ) if nodes is not lib._no_val else ()
+
+    for node in cmds.ls(*args, type="file"):
+        attr = node + ".fileTextureName"
+        path = cmds.getAttr(attr, expandEnvironmentVariables=True)
+        embedded_path = env_embedded_path(path)
+        cmds.setAttr(attr, embedded_path, type="string")
+
+
 def _hash_MPoint(x, y, z, w):
     x = (x + 1) * 233
     y = (y + x) * 239

--- a/reveries/plugins.py
+++ b/reveries/plugins.py
@@ -495,6 +495,11 @@ class PackageExtractor(pyblish.api.InstancePlugin):
         This should NOT be re-implemented.
 
         """
+        context = instance.context
+        # If any error occurred, skip extraction.
+        assert all(result["success"] for result in context.data["results"]), (
+            "Atomicity not held, aborting.")
+
         self._process(instance)
         self.extract()
 

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -751,7 +751,7 @@ Resolution: {width}px * {height}px
         # Put resized original image into new image that has clipinfo
         # overlaied
         im.paste(background.resize((scaled_w, scaled_h),
-                 resample=Image.BICUBIC),
+                                   resample=Image.BICUBIC),
                  box=box)
 
     # save over to original image


### PR DESCRIPTION

## Change Notes

All commits' motives are listed below.


### Cancel all extractions if error occurred
Since any error will stop integration, so not to wast time if the error already happened in any extraction.

- e214056: `plugins: Skip extraction if any error occurred`


### Auto remove `setAttr` type reference edit when updating Look
Look should not be modified by any downstream artists, but if edit is required, use inventory action *"Update Preserve Edit"* to update.

- fed7e9a: `Implement reference edit droppable update`


### Implement scene state collector and validator
After startup Pyblish-QML, it ran all collector plugins automatically and wait for next action.

At this point, artist may still tweaking scene and forgot to reset Pyblish to update those changes he/she just made. If that happens, may end up publishing incorrect content.

I don't like the idea to just set Pyblish-QML to run all validation once rest or startup, so I came up with this. By tracking Maya's *undo queue*. If there are any undo command that is not a simple `select` after collecting completed, consider this scene has been modified and require to reset Pyblish.

- e1aa2f5: `plugins.maya: Implement scene state collector and validator`
- d229205: `maya.capsule: Bug fix`
- d646161: `maya.capsule: Remove deprecated`
- 4df4071: `maya.capsule: Add Maya log recording context`


### Revert back to use environment variables in texture file path
Also, release medicine for fixing workfile via Maya callback

- 8f64ad0: `maya.utils: Add texture path env var expand/embed helper`
- cb787ed: `Re-implement environment variables embedded texture file path`
- b6a9bd7: `maya.utils: Add texture file path fixing helper`
- 0b01ca7: `Fixing previous bad implementations on texture management`
- 468da68: `maya.callbacks: Change to fix only containerized file nodes`


### Resolve TX map update and texture color space issues
On each texture file:
1. Ensure colorspace is unlocked
1. Enable ignore color space file rule, to prevent any change
1. Disable auto generate TX map on each file node
1. Ensure TX update without error

- 33dc6ed: `Resolve TX map update and texture color space issues`
- 5cc79a1: `plugins.maya: Decouple texture file collect and resolve functions`
- e8bb732: `plugins.maya: Directly use TX map in file node is not allowed`
- 7936243: `plugins.maya: Improve 'fileNodeAttrs' exchange mechanism`


### Add `avalon-sfptc` job export helper for uploading
- 1c5aef7: `maya.utils: Add Avalon SFTPC job export helper`


### Fix missed shading upstream nodes
Some of the upstream node will not be collected if not using `allConnections` flag in `listHistory` command. This seems only happened on some of plugin nodes.

- 6a05463: `plugins.maya: Fix missed shading upstream nodes`


### Minor fixes
- e8f0730: `Cosmetic`
- dffac95: `plugins.maya: Rename and fix action`