### PR TITLE
Fix bug in render publishing when renderSetup enabled

### DIFF
--- a/plugins/maya/publish/collect_renderlayers.py
+++ b/plugins/maya/publish/collect_renderlayers.py
@@ -59,9 +59,10 @@ class CollectRenderlayers(pyblish.api.InstancePlugin):
         collected = False
         for layer in renderlayers:
 
-            render_cams = lib.ls_renderable_cameras(layer)
+            all_render_cams = lib.ls_renderable_cameras(layer)
+            render_cams = list(set(cameras).intersection(set(all_render_cams)))
 
-            if not set(cameras).intersection(set(render_cams)):
+            if not render_cams:
                 continue
             collected = True
 
@@ -93,7 +94,7 @@ class CollectRenderlayers(pyblish.api.InstancePlugin):
                 "renderer": renderer,
                 "fileNamePrefix": utils.get_render_filename_prefix(layer),
                 "fileExt": ext,
-                "renderCam": cameras,
+                "renderCam": render_cams,
             }
 
             data.update(original.data)

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -297,6 +297,7 @@ def query_by_setuplayer(node, attr, layer):
 
     # Locate leaf collection and get overrides from there
 
+    in_selection = None
     overrides = []
 
     for item in walk_hierarchy(highest_col[0]):
@@ -304,16 +305,18 @@ def query_by_setuplayer(node, attr, layer):
             selector = cmds.listConnections(item + ".selector")[0]
         except ValueError:
             # Is an override
-            if item in enabled_overrides:
+            if in_selection and item in enabled_overrides:
                 overrides.append(item)
 
         else:
             # Is a collection
+            in_selection = False
             if is_selected_by(selector):
                 if not cmds.getAttr(item + ".selfEnabled"):
                     # Collection not enabled, not a member
                     return original_value()
 
+                in_selection = True
                 overrides = []
 
     if not overrides:


### PR DESCRIPTION
Renderable cameras was not collected correctly with attribute overrides via `renderSetup`, this fixed the issue.
