### PR TITLE
Supporting multiple FPS project

### DIFF
--- a/plugins/maya/publish/collect_timeline.py
+++ b/plugins/maya/publish/collect_timeline.py
@@ -1,6 +1,5 @@
 
 import maya.cmds as cmds
-import maya.mel as mel
 import pyblish.api
 
 
@@ -13,10 +12,12 @@ class CollectTimeline(pyblish.api.ContextPlugin):
     label = "Scene Timeline"
 
     def process(self, context):
+        from reveries.maya import lib
+
         context.data.update(
             {
                 "startFrame": cmds.playbackOptions(query=True, minTime=True),
                 "endFrame": cmds.playbackOptions(query=True, maxTime=True),
-                "fps": mel.eval('currentTimeUnitToFPS()'),
+                "fps": lib.current_fps(),
             }
         )

--- a/plugins/maya/publish/validate_timeline.py
+++ b/plugins/maya/publish/validate_timeline.py
@@ -53,13 +53,14 @@ class ValidateTimeline(pyblish.api.InstancePlugin):
             self.log.info("No range been set on this asset, skipping..")
             return True
 
-        project = context.data["projectDoc"]
-        proj_start, proj_end, fps = utils.compose_timeline_data(project,
-                                                                asset_name)
-
         scene_start = context.data.get("startFrame")
         scene_end = context.data.get("endFrame")
         scene_fps = context.data.get("fps")
+
+        project = context.data["projectDoc"]
+        proj_start, proj_end, fps = utils.compose_timeline_data(project,
+                                                                asset_name,
+                                                                scene_fps)
 
         # Check if any of the values are present
         if any(value is None for value in (scene_start, scene_end)):

--- a/res/.inventory.toml
+++ b/res/.inventory.toml
@@ -6,6 +6,7 @@ schema = "avalon-core:inventory-1.0"
 resolution_width = 1920
 resolution_height = 1080
 fps = 30
+fpses = []
 handles = 1
 edit_in = 101
 edit_out = 200

--- a/reveries/maya/lib.py
+++ b/reveries/maya/lib.py
@@ -64,6 +64,10 @@ FPS_MAP = {
 }
 
 
+def current_fps():
+    return round(mel.eval('currentTimeUnitToFPS()'), 3)
+
+
 def is_using_renderSetup():
     """Is Maya currently using renderSetup system ?"""
     try:

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -518,6 +518,9 @@ def has_turntable():
         return turntable
 
 
+_current_fps = {"_": None}
+
+
 def set_scene_timeline(project=None, asset_name=None, strict=True):
     """Set timeline to correct frame range for the asset
 
@@ -535,7 +538,8 @@ def set_scene_timeline(project=None, asset_name=None, strict=True):
     """
     log.info("Timeline setting...")
 
-    current_fps = lib.current_fps()
+    current_fps = _current_fps["_"] or lib.current_fps()
+    _current_fps["_"] = None
 
     start_frame, end_frame, fps = utils.compose_timeline_data(project,
                                                               asset_name,

--- a/reveries/maya/pipeline.py
+++ b/reveries/maya/pipeline.py
@@ -535,8 +535,11 @@ def set_scene_timeline(project=None, asset_name=None, strict=True):
     """
     log.info("Timeline setting...")
 
+    current_fps = lib.current_fps()
+
     start_frame, end_frame, fps = utils.compose_timeline_data(project,
-                                                              asset_name)
+                                                              asset_name,
+                                                              current_fps)
     fps = lib.FPS_MAP.get(fps)
 
     if fps is None:

--- a/reveries/utils.py
+++ b/reveries/utils.py
@@ -56,7 +56,7 @@ def clear_stage(prefix="pyblish_tmp_"):
     os.chdir(cwd_backup)
 
 
-def get_timeline_data(project=None, asset_name=None):
+def get_timeline_data(project=None, asset_name=None, current_fps=None):
     """Get asset timeline data from project document
 
     Get timeline data from asset if asset has it's own settings, or get from
@@ -67,6 +67,8 @@ def get_timeline_data(project=None, asset_name=None):
             not provided.
         asset_name (str, optional): Asset name, get from `avalon.Session` if
             not provided.
+        current_fps (float, optional): For preserving current FPS setting if
+            project has multiple valid FPS.
 
     Returns:
         edit_in (int),
@@ -91,10 +93,15 @@ def get_timeline_data(project=None, asset_name=None):
     handles = get("handles")
     fps = get("fps")
 
+    # If project has multiple valid FPS, try preserving current FPS
+    fpses = project["data"].get("fpses")
+    if fpses and current_fps in fpses:
+        fps = current_fps
+
     return edit_in, edit_out, handles, fps
 
 
-def compose_timeline_data(project=None, asset_name=None):
+def compose_timeline_data(project=None, asset_name=None, current_fps=None):
     """Compute and return start frame, end frame and fps
 
     Get timeline data from asset if asset has it's own settings, or get from
@@ -105,6 +112,8 @@ def compose_timeline_data(project=None, asset_name=None):
             not provided.
         asset_name (str, optional): Asset name, get from `avalon.Session` if
             not provided.
+        current_fps (float, optional): For preserving current FPS setting if
+            project has multiple valid FPS.
 
     Returns:
         start_frame (int),
@@ -112,7 +121,9 @@ def compose_timeline_data(project=None, asset_name=None):
         fps (float)
 
     """
-    edit_in, edit_out, handles, fps = get_timeline_data(project, asset_name)
+    edit_in, edit_out, handles, fps = get_timeline_data(project,
+                                                        asset_name,
+                                                        current_fps)
     start_frame = edit_in - handles
     end_frame = edit_out + handles
 


### PR DESCRIPTION
One of our project requires two FPS unit. In previous implementation, only one FPS will be preserved on scene reset, so it's a bit annoying for artists who were more often working on the other.