### PR TITLE
Don't containerize shapes with Maya ReferenceLoader to avoid maya bug

### DIFF
--- a/plugins/maya/publish/extract_model.py
+++ b/plugins/maya/publish/extract_model.py
@@ -51,7 +51,6 @@ class ExtractModel(PackageExtractor):
         clay_shader = "initialShadingGroup"
 
         # Perform extraction
-        self.log.info("Extracting %s" % str(self.member))
         cmds.select(self.member, noExpand=True)
 
         with contextlib.nested(


### PR DESCRIPTION
Thanks to Colorbleed/colorbleed-config#262 and ensuring no `groupId` node being exported when exporting models.

We MUST excluding `groupId` nodes because :
https://gitter.im/getavalon/Lobby?at=5dd39d706ba2347d2dbe63a5

> David Lai @davidlatwe 15:28
About the issue that assigning shaders on instanced nodes and lost shading after re-open the file, I found that if the referenced model has `groupId` node connected, shader always lost :S
Excluding shape nodes and groupId nodes from objectSet doesn't work.
>
> David Lai @davidlatwe 15:44
You may reproduce the case by:
> 1. Create a simple cube
> 1. Face assign a shader other than lambert1
> 1. In face selection mode, select all faces and assign back to lambert1 (and you will get a mesh with groupId nodes connected)
> 1. Save this model and reference it into a new scene
> 1. Put referenced model into an objectSet (no need to group it, and no need to put shape node into set)
> 1. Assign a shader (the shader doesn't need to be referenced)
> 1. Create instance of the model
> 1. Save the scene and re-open, instanced mode has lost the shader.
>
> I was in Maya 2018.6 (Windows)