### PR TITLE
Houdini features update - Shader workflow

### DIFF
--- a/reveries/houdini/lib.py
+++ b/reveries/houdini/lib.py
@@ -10,7 +10,7 @@ from avalon import api, io
 from avalon.houdini import lib as houdini
 
 
-# Get Houdini root nodes
+# Get Houdini root node
 sceneRoot = hou.node('/obj/')
 
 
@@ -206,61 +206,117 @@ def set_scene_fps(fps):
     hou.setFps(fps)
 
 
-def export_nodes(export_nodes_paths, file_path):
-    """Export nodes as ".cpio" text file.
+def export_nodes(nodes_paths, file_path):
+    """Export nodes as text file.
 
-    list node's paths to select export nodes:
-    >>> export_nodes_paths = ['/obj/pp', '/obj/geo1']
+    Example:
+        sceneRoot = hou.node('/obj/')
+        nodes_paths = ["/obj/nono_shader_day", "/obj/nono_shader_night"]
+        file = "O:/Project/Char/Nono/publish/Nono_shader.cpio"
+        export_nodes(nodes_paths, file)
+        # Result: "output file"
+
+    Args:
+        nodes_paths(list): List of nodes' path
+        file_path(str): cpio format file path
 
     """
-    nodes = hou.nodes(export_nodes_paths)
-    path = os.path.abspath(file_path + '.cpio')
+
+    nodes = hou.nodes(nodes_paths)
+    path = os.path.abspath(file_path)
     sceneRoot.saveChildrenToFile(nodes, [], path)
 
 
 def load_nodes(file_path):
-    file = os.path.abspath(file_path + '.cpio')
+    """Load nodes from text file.
+
+    Example:
+        sceneRoot = hou.node('/obj/')
+        file = "O:/Project/Char/Nono/publish/Nono_shader.cpio"
+        load_nodes(file)
+
+    Args:
+        file_path(str): cpio format file path
+
+    Returns:
+        hou.Nodes
+
+    """
+
+    file = os.path.abspath(file_path)
     sceneRoot.loadItemsFromFile(file)
 
 
-def export_shaderparm(asset_node, shader_file_path):
-    """Export nodes's shader parm to ".json" file.
+def export_shaderparm(node, shader_file_path):
+    """Export char nodes's shader parm to file.
 
-    Select asset node to export parm:
-    >>> char = hou.node('/obj/char_nono')
+    Example:
+        char = hou.node("/obj/char_nono")
+        char_shader_path = "O:/Project/Char/Nono/publish/stylesheet.json"
+        export_shaderparm(char, char_shader_path)
+        # Result: "output file"
+
+    Args:
+        node(hou.Node): node instance
+        shader_file_path(str): json format file path
 
     """
-    stylesheet_data = asset_node.parm('shop_materialstylesheet').eval()
+    stylesheet_data = node.parm('shop_materialstylesheet').eval()
     with open(shader_file_path, 'w') as f:
         f.write(stylesheet_data)
         f.close()
 
 
-def assign_shaderparm(asset_node, shader_file_path):
-    """Add shader parm to asset by reading shader ".json" file.
+def assign_shaderparm(node, shader_file_path):
+    """Add shader parm to node by reading shader file's data.
 
-    Select asset node to add parm:
-    >>> char = hou.node('/obj/char_nono')
+    Example:
+        char = hou.node("/obj/char_nono")
+        char_shader_path = "O:/Project/Char/Nono/publish/stylesheet.json"
+        assign_shaderparm(char, char_shader_path)
+        # Result: "output"
+
+    Args:
+        node(hou.Node): node instance
+        shader_file_path(str): json format file path
+
+    Returns:
+        hou.Parm
 
     """
+
     data_tags = {'script_action_icon': 'DATATYPES_stylesheet',
             'script_action_help': 'Open in Material Style Sheet editor.',
             'spare_category': 'Shaders',
             'script_action': "import toolutils\np = toolutils.dataTree('Material Style Sheets')\np.setCurrentPath(kwargs['node'].path() + '/Style Sheet Parameter')",
             'editor': '1'}
-    group = asset_node.parmTemplateGroup()
+    group = node.parmTemplateGroup()
     folder = hou.FolderParmTemplate('folder', 'Shaders')
     folder.addParmTemplate(hou.StringParmTemplate('shop_materialstylesheet', 'Material Style Sheet', 1, tags=data_tags))
     group.append(folder)
-    asset_node.setParmTemplateGroup(group)
+    node.setParmTemplateGroup(group)
 
     file = open(shader_file_path, 'r')
     data = json.load(file)
     data_convert = json.dumps(data, indent=4)
-    asset_node.parm('shop_materialstylesheet').set(data_convert)
+    node.parm('shop_materialstylesheet').set(data_convert)
 
 
 def create_empty_shadernetwork(asset_name):
+    """Create asset's SOP shader network.
+
+    Example:
+        sceneRoot = hou.node('/obj/')
+        name = "char_nono"
+        create_empty_shadernetwork(name)
+
+    Args:
+        asset_name(str): name of the asset
+
+    Returns:
+        hou.Nodes
+
+    """
     shaderpack_name = 'SHADER_' + str.upper(asset_name)
     shaderpack_node = sceneRoot.createNode('geo', shaderpack_name)
     shaderpack_node.setColor(hou.Color(0.282353, 0.819608, 0.8))


### PR DESCRIPTION
## Features

- 新增Houdini輸出節點與輸入節點功能

- 創建以Asset模型命名的空的材質節點包，在內創建材質以便後續Publish作業。


### Function 

- **輸出節點 export_nodes**
    將路徑清單內的節點與其下的節點輸出成cpio格式文字檔

    Function:
    ```python
    def export_nodes(nodes_paths, file_path):

        nodes = hou.nodes(nodes_paths)
        path = os.path.abspath(file_path)
        sceneRoot.saveChildrenToFile(nodes, [], path)
    ```

    Args:
    ```python
    nodes_paths(list): List of nodes' path
    file_path(str): cpio format file path
    ```
   
   Example:
   ```python
    sceneRoot = hou.node('/obj/')
    nodes_paths = ['/obj/nono_shader_day', '/obj/nono_shader_night']
    file = 'O:/Project/Char/Nono/publish/Nono_shader.cpio'
    export_nodes(nodes_paths, file)
    # Result: "output file"
    ```



- **輸入節點 load_nodes**
    將儲存節點資訊的cpio格式文字檔輸入Houdini轉換為節點

    Function:
    ```python
    def load_nodes(file_path):

        file = os.path.abspath(file_path)
        sceneRoot.loadItemsFromFile(file)
    ```

    Args:
    ```python
    file_path(str): cpio format file path
    ```
   
   Example:
   ```python
    sceneRoot = hou.node('/obj/')
    file = 'O:/Project/Char/Nono/publish/Nono_shader.cpio'
    load_nodes(file)
    # Result: "create nodes"
    ```

- **輸出節點材質屬性 export_shaderparm**
    將asset節點的材質屬性輸出為json資料格式

    Function:
    ```python
    def export_shaderparm(node, shader_file_path):

        stylesheet_data = node.parm('shop_materialstylesheet').eval()
        with open(shader_file_path, 'w') as f:
            f.write(stylesheet_data)
            f.close()
    ```

    Args:
    ```python
    node(hou.Node): node instance
    shader_file_path(str): json format file path
    ```
   
   Example:
   ```python
    char = hou.node('/obj/char_nono')
    char_shader_path = 'O:/Project/Char/Nono/publish/stylesheet.json'
    export_shaderparm(char, char_shader_path)
    # Result: "output file"
    ```

- **輸入節點材質屬性 assign_shaderparm**
    將儲存材質資訊的json資料輸入至asset節點的材質屬性

    Function:
    ```python
    def assign_shaderparm(node, shader_file_path):
        
        data_tags = {'script_action_icon': 'DATATYPES_stylesheet',
                'script_action_help': 'Open in Material Style Sheet editor.',
                'spare_category': 'Shaders',
                'script_action': (
                    "import tooltils"
                    "p = toolutils.dataTree('Material Style Sheets')"
                    "p.setCurrentPath(kwargs['node'].path() + '/Style Sheet Parameter')"
                ),
                'editor': '1'}
        group = node.parmTemplateGroup()
        folder = hou.FolderParmTemplate('folder', 'Shaders')
        parm_string = hou.StringParmTemplate(
            name='shop_materialstylesheet',
            label='Material Style Sheet',
            num_components=1,
            tags=data_tags
        )
        folder.addParmTemplate(parm_string)
        group.append(folder)
        node.setParmTemplateGroup(group)
        
        with open(shader_file_path, 'r') as file:
            data = json.load(file)
            data_convert = json.dumps(data, indent=4)
            node.parm('shop_materialstylesheet').set(data_convert)
            file.close()

    ```

    Args:
    ```python
    node(hou.Node): node instance
    shader_file_path(str): json format file path
    ```
   
   Example:
   ```python
    char = hou.node('/obj/char_nono')
    char_shader_path = 'O:/Project/Char/Nono/publish/stylesheet.json'
    assign_shaderparm(char, char_shader_path)
    # Result: "hou.Parm"
    ```

- **創建空的材質節點包 create_empty_shadernetwork**
    創建空的asset SOP材質節點包，以便於後續publish作業

    Function:
    ```python
    def create_empty_shadernetwork(asset_name):

        NODE_COLOR = (0.282353, 0.819608, 0.8)
        NODE_POS = (3, 0)
 
        shaderpack_name = 'SHADER_' + asset_name.upper()
        shaderpack_node = sceneRoot.createNode('geo', shaderpack_name)
        shaderpack_node.setColor(hou.Color(*NODE_COLOR))

        shaderpack_node.createNode('shopnet', 'shopnet')
        shaderpack_node.createNode('matnet', 'matnet').setPosition(hou.Vector2(*NODE_POS))
        shaderpack_node.setCurrent(on=True, clear_all_selected=True)
        shaderpack_node.setDisplayFlag(True)
    ```

    Args:
    ```python
    asset_name(str): name of the asset
    ```
   
   Example:
   ```python
    sceneRoot = hou.node('/obj/')
    name = 'char_nono'
    create_empty_shadernetwork(name)
    # Result: "hou.Nodes"
    ```


