### PR TITLE
Fix hierarchy update

### DIFF
--- a/plugins/maya/load/load_arnold_standin.py
+++ b/plugins/maya/load/load_arnold_standin.py
@@ -90,6 +90,7 @@ class ArnoldAssLoader(ImportLoader, avalon.api.Loader):
 
     def update(self, container, representation):
         import maya.cmds as cmds
+        from avalon import io
         from reveries.maya import pipeline
         from reveries.utils import get_representation_path_
 
@@ -99,7 +100,7 @@ class ArnoldAssLoader(ImportLoader, avalon.api.Loader):
         if not standins:
             raise Exception("No Arnold Stand-In node, this is a bug.")
 
-        parents = avalon.io.parenthood(representation)
+        parents = io.parenthood(representation)
         self.package_path = get_representation_path_(representation, parents)
 
         entry_path, use_sequence = self.retrive(representation)

--- a/reveries/maya/hierarchy.py
+++ b/reveries/maya/hierarchy.py
@@ -328,12 +328,10 @@ def change_subset(container, data, namespace, root):
     """
     from avalon.pipeline import get_representation_context
 
-    current_repr_id = container["representation"]
-    current_repr = get_representation_context(current_repr_id)
-    loader = data["loaderCls"](current_repr)
-
-    new_repr = data["representationDoc"]
-    loader.update(container, new_repr)
+    if data["representation"] != container["representation"]:
+        current_repr = get_representation_context(container["representation"])
+        loader = data["loaderCls"](current_repr)
+        loader.update(container, data["representationDoc"])
 
     try:
         # Update parenting and matrix

--- a/reveries/maya/plugins.py
+++ b/reveries/maya/plugins.py
@@ -36,7 +36,7 @@ from .hierarchy import (
     get_loader,
     add_subset,
     change_subset,
-    get_referenced_containers,
+    get_updatable_containers,
 )
 
 
@@ -533,8 +533,18 @@ class HierarchicalLoader(MayaBaseLoader):
         # should coming from `options`
         force_update = container.pop("_force_update", False)
 
+        nodes = cmds.sets(container["objectName"], query=True)
+        reference_node = next(iter(lib.get_reference_nodes(nodes)), None)
+
+        if reference_node is None:
+            title = "Abort"
+            message = ("This subset has been imported and cannot be updated.")
+            self.log.error(message)
+            message_box_error(title, message)
+            raise RuntimeError(message)
+
         # Get and check current sub-containers
-        reference_node, current_subcons = get_referenced_containers(container)
+        current_subcons = get_updatable_containers(container)
 
         # Load members data
         parents = avalon.io.parenthood(representation)


### PR DESCRIPTION
This fixes the "Imported container not supported.." RuntimeError when updating hierarchical subset like `set-dressing`, which containing Arnold Stand-in type of child subset in Maya.

Also change to only updating outdated child subset, which will improved the process speed.
