### PR TITLE
Stop publish when Maya referencing unknown nodes

### DIFF
--- a/plugins/maya/publish/validate_no_unknown_nodes.py
+++ b/plugins/maya/publish/validate_no_unknown_nodes.py
@@ -15,7 +15,7 @@ class DeleteUnknownNodes(RepairContextAction):
     label = "Delete Unknown"
 
 
-class ValidateUnknownNodes(pyblish.api.InstancePlugin):
+class ValidateNoUnknownNodes(pyblish.api.InstancePlugin):
     """Can not publish unknown nodes
     """
 

--- a/plugins/maya/publish/validate_no_unknown_nodes_referenced.py
+++ b/plugins/maya/publish/validate_no_unknown_nodes_referenced.py
@@ -10,7 +10,7 @@ class SelectUnknownNodes(MayaSelectInvalidContextAction):
 
 
 class ValidateNoUnknownNodesReferenced(pyblish.api.InstancePlugin):
-    """Can not publish with unknown nodes referenced
+    """Please not publishing when unknown nodes have been referenced
     """
 
     order = pyblish.api.ValidatorOrder - 0.1
@@ -42,8 +42,5 @@ class ValidateNoUnknownNodesReferenced(pyblish.api.InstancePlugin):
     def process(self, context):
         unknown = self.get_invalid(context)
 
-        for node in unknown:
-            self.log.error(node)
-
         if unknown:
-            raise Exception("Scene referenced unknown nodes.")
+            self.log.warning("Scene referenced unknown nodes.")

--- a/plugins/maya/publish/validate_no_unknown_nodes_referenced.py
+++ b/plugins/maya/publish/validate_no_unknown_nodes_referenced.py
@@ -1,0 +1,49 @@
+
+import pyblish.api
+from reveries.plugins import context_process
+from reveries.maya.plugins import MayaSelectInvalidContextAction
+
+
+class SelectUnknownNodes(MayaSelectInvalidContextAction):
+
+    label = "Select Unknown"
+
+
+class ValidateNoUnknownNodesReferenced(pyblish.api.InstancePlugin):
+    """Can not publish with unknown nodes referenced
+    """
+
+    order = pyblish.api.ValidatorOrder - 0.1
+    label = "No Unknown Nodes Referenced"
+    host = ["maya"]
+    families = [
+        "reveries.model",
+        "reveries.rig",
+        "reveries.look",
+        "reveries.xgen",
+        "reveries.camera",
+        "reveries.mayashare",
+        "reveries.standin",
+        "reveries.lightset",
+    ]
+
+    actions = [
+        pyblish.api.Category("Select"),
+        SelectUnknownNodes,
+    ]
+
+    @classmethod
+    def get_invalid(cls, context):
+        from maya import cmds
+        return [node for node in cmds.ls(type="unknown")
+                if cmds.referenceQuery(node, isNodeReferenced=True)]
+
+    @context_process
+    def process(self, context):
+        unknown = self.get_invalid(context)
+
+        for node in unknown:
+            self.log.error(node)
+
+        if unknown:
+            raise Exception("Scene referenced unknown nodes.")


### PR DESCRIPTION
This PR adds a validator that will show warning when Maya scene contains any referenced unknown node.

If a scene contains any referenced unknown node, may encounter unpredictable behavior that might crashes Maya. For example, there was a shared reference node in this [case](https://gist.github.com/davidlatwe/f8491b974ea32f9df86f05007571febc) and will crash Maya on file save after publish process completed. But as you can see, the condition to make Maya crash in that case was rare, so instead of stopping publish process by raising error, just show the warning.