### PR TITLE
Imp projectmember

### DIFF
--- a/docs/avalon_launcher.md
+++ b/docs/avalon_launcher.md
@@ -1,0 +1,34 @@
+
+![launcher](https://user-images.githubusercontent.com/3357009/75664932-45014f00-5cae-11ea-8269-3c9bd169b0d1.png)
+
+列出所有已登記在 Avalon 資料庫的專案，Avalon 專案進入點。
+
+!!! note
+    視窗關閉後並不會結束程式，會常駐於右下角的工作列裡。 若要完全關閉，請在工作列的 Avalon 圖示按右鍵並點擊 `Quit`
+
+!!! hint
+    Launcher 首頁僅會列出使用者收藏清單裡的專案。 若列表為空，或想存取的專案不在列表裡，請使用 [Favorites](avalon_launcher.md#favorites) 工具編輯收藏清單。
+
+### Favorites
+
+![image](https://user-images.githubusercontent.com/3357009/75665559-4e3eeb80-5caf-11ea-9b7c-8fe933076f6a.png)
+
+將專案登記為收藏，或從收藏列表移除。
+
+#### 加入
+
+啟動之後，從列表中選取要登記的專案，如果選取的專案尚未加入收藏清單，點擊 <i class="fa fa-user-plus" style="color: #58D68D;"></i> 按鈕即可新增。
+
+![image](https://user-images.githubusercontent.com/3357009/75665324-f56f5300-5cae-11ea-884a-8ed1ea76a594.png)
+
+#### 移除
+
+啟動之後，從列表中選取要刪除的專案，如果選取的專案已經加入收藏清單，點擊 <i class="fa fa-user-times" style="color: #A93226;"></i> 按鈕即可移除。
+
+![image](https://user-images.githubusercontent.com/3357009/75665387-0c15aa00-5caf-11ea-81aa-2ca959459cb8.png)
+
+#### 重整 Launcher
+
+完成編輯後，點擊 Luncher 首頁返回按鈕 <i class="fa fa-home" style="color: white;"></i> 就會刷新專案清單。
+
+![image](https://user-images.githubusercontent.com/3357009/75666174-59464b80-5cb0-11ea-9b5b-b9692f42a183.png)

--- a/docs/stylesheets/doc.css
+++ b/docs/stylesheets/doc.css
@@ -1,3 +1,13 @@
+body {
+	background: #D6DBDF;
+}
+
 p {
   font-size: 85%;
+}
+
+i.fa {
+  	background: #404040;
+  	border: 4px solid #404040;
+  	border-radius: 6px;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Release Notes: release_notes.md
   - Avalon:
     - Overview: avalon_overview.md
+    - Launcher: avalon_launcher.md
     - Tools:
       - Project Manager: avalon_tool_project_mgr.md
       - Context Manager: avalon_tool_context_mgr.md
@@ -41,3 +42,4 @@ markdown_extensions:
 
 extra_css:
   - stylesheets/doc.css
+  - https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css

--- a/plugins/global/launcher/avalon_project_member.py
+++ b/plugins/global/launcher/avalon_project_member.py
@@ -1,0 +1,19 @@
+
+from avalon import api, lib
+
+
+class ProjectMemberAction(api.Action):
+
+    name = "projectmember"
+    label = "Favorites"
+    icon = "heart"
+    color = "#E74C3C"
+    order = 999     # at the end
+
+    def is_compatible(self, session):
+        """Return whether the action is compatible with the session"""
+        return "AVALON_PROJECTS" in session and "AVALON_PROJECT" not in session
+
+    def process(self, session, **kwargs):
+        return lib.launch(executable="python",
+                          args=["-u", "-m", "reveries.tools.projectmember"])

--- a/reveries/__init__.py
+++ b/reveries/__init__.py
@@ -32,6 +32,9 @@ REVERIES_ICONS = os.path.join("$REVERIES_PATH", "res", "icons")
 
 os.environ["REVERIES_PATH"] = os.path.dirname(PACKAGE_DIR)
 
+# Show project only if user has registered as member
+os.environ["AVALON_LAUNCHER_USE_PROJECT_MEMBER"] = "true"
+
 # Deadline command application path
 avalon.Session["AVALON_DEADLINE_APP"] = os.getenv("AVALON_DEADLINE_APP", "")
 

--- a/reveries/tools/projectmember/__init__.py
+++ b/reveries/tools/projectmember/__init__.py
@@ -1,0 +1,10 @@
+from .app import (
+    show,
+    cli,
+)
+
+
+__all__ = [
+    "show",
+    "cli",
+]

--- a/reveries/tools/projectmember/__main__.py
+++ b/reveries/tools/projectmember/__main__.py
@@ -1,0 +1,5 @@
+from . import cli
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(cli())

--- a/reveries/tools/projectmember/app.py
+++ b/reveries/tools/projectmember/app.py
@@ -1,0 +1,135 @@
+
+import sys
+import getpass
+
+from avalon import io, style
+from avalon.tools import lib as tools_lib
+from avalon.vendor import qtawesome
+from avalon.vendor.Qt import QtWidgets, QtCore
+
+
+module = sys.modules[__name__]
+module.window = None
+
+
+class Window(QtWidgets.QWidget):
+
+    _user = getpass.getuser().lower()
+
+    def __init__(self, parent=None):
+        super(Window, self).__init__(parent=parent)
+
+        self.setWindowIcon(qtawesome.icon("fa.users", color="#F0F3F4"))
+        self.setWindowTitle("Project Member")
+        self.setWindowFlags(QtCore.Qt.Window)
+
+        widget = {
+            "refresh": QtWidgets.QPushButton(),
+            "projects": QtWidgets.QComboBox(),
+            "btnAdd": QtWidgets.QPushButton(),
+            "btnDel": QtWidgets.QPushButton(),
+        }
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.addWidget(widget["refresh"])
+        layout.addWidget(widget["projects"], stretch=True)
+        layout.addWidget(widget["btnAdd"])
+        layout.addWidget(widget["btnDel"])
+
+        widget["refresh"].setIcon(qtawesome.icon("fa.refresh",
+                                                 color="#E5E7E9"))
+        widget["btnAdd"].setIcon(qtawesome.icon("fa.user-plus",
+                                                color="#58D68D"))
+        widget["btnDel"].setIcon(qtawesome.icon("fa.user-times",
+                                                color="#A93226"))
+
+        widget["projects"].currentTextChanged.connect(self.on_text_changed)
+        widget["refresh"].clicked.connect(self.on_refresh_clicked)
+        widget["btnAdd"].clicked.connect(self.on_add_clicked)
+        widget["btnDel"].clicked.connect(self.on_del_clicked)
+
+        self.widget = widget
+        self.init_projects()
+        self.resize(480, 40)
+
+    def init_projects(self):
+        self._projects = {
+            project["name"]: project
+            for project in io.projects()
+            if project["data"].get("visible", True)  # Discard hidden projects
+        }
+        self.widget["projects"].addItems(sorted(self._projects.keys()))
+
+    def on_text_changed(self, text):
+        self.widget["btnAdd"].setEnabled(False)
+        self.widget["btnDel"].setEnabled(False)
+
+        def on_changed():
+            project = self._projects[text]
+            member = project["data"].get("role", {}).get("member", [])
+            if self._user in member:
+                self.widget["btnDel"].setEnabled(True)
+            else:
+                self.widget["btnAdd"].setEnabled(True)
+
+        tools_lib.schedule(on_changed, 400, channel="projectmember")
+
+    def on_refresh_clicked(self):
+        self.widget["projects"].clear()
+        self.init_projects()
+
+    def on_add_clicked(self):
+        name = self.widget["projects"].currentText()
+
+        col = self._get_project_collection(name)
+        col.update_one({"type": "project"},
+                       {"$addToSet": {"data.role.member": self._user}})
+
+        self._update_project_data(name)
+
+        self.widget["btnAdd"].setEnabled(False)
+        self.widget["btnDel"].setEnabled(True)
+
+    def on_del_clicked(self):
+        name = self.widget["projects"].currentText()
+
+        col = self._get_project_collection(name)
+        col.update_one({"type": "project"},
+                       {"$pull": {"data.role.member": self._user}})
+
+        self._update_project_data(name)
+
+        self.widget["btnAdd"].setEnabled(True)
+        self.widget["btnDel"].setEnabled(False)
+
+    @io.auto_reconnect
+    def _update_project_data(self, name):
+        col = self._get_project_collection(name)
+        project = col.find_one({"type": "project"})
+        self._projects[name] = project
+        return project
+
+    @io.auto_reconnect
+    def _get_project_collection(self, name):
+        return io._database[name]
+
+
+def show():
+    """Display Main GUI"""
+    try:
+        module.window.close()
+        del module.window
+    except (RuntimeError, AttributeError):
+        pass
+
+    with tools_lib.application():
+        window = Window(parent=None)
+        window.setStyleSheet(style.load_stylesheet())
+        window.show()
+
+        module.window = window
+
+
+def cli():
+    io.install()
+    show()


### PR DESCRIPTION
### Motivation

Some of our artists are complaining the project page in Avalon Launcher is too long, and hoping that there is a way to filter out projects which they don't involve any more.

### Implementation

With MoonShineVFX/launcher#1, this PR enables registering **favorite projects** for easing out the problem.

By setting environment variable `AVALON_LAUNCHER_USE_PROJECT_MEMBER`, the Launcher will only show projects that user has been registered in project document's `data.role.member` field.

To register user into project's document, use the launcher action `ProjectMemberAction`.