### PR TITLE
Enable to publish asset that is different from current session

### DIFF
--- a/plugins/global/publish/validate_asset_session.py
+++ b/plugins/global/publish/validate_asset_session.py
@@ -29,16 +29,29 @@ class ValidateAssetSession(pyblish.api.InstancePlugin):
     order = pyblish.api.ValidatorOrder - 0.45
 
     def process(self, instance):
+        from avalon import io
+
         asset = instance.data["asset"]
         task_asset = avalon.api.Session["AVALON_ASSET"]
 
         if not asset == task_asset:
-            msg = ("Instance {name!r} has been set to be as part of "
-                   "Asset: {asset!r}, but the current publish session "
-                   "is Asset: {task_asset!r}. "
-                   "Please check Context Manager."
-                   "".format(name=str(instance.data["name"]),
-                             asset=str(asset),
-                             task_asset=str(task_asset)))
-            self.log.error(msg)
-            raise AssertionError(msg)
+
+            if instance.data.get("assetConfirmed"):
+                self.log.warning("Publishing asset that is not in current "
+                                 "session.")
+
+                if not io.find_one({"type": "asset", "name": asset}):
+                    msg = "Asset name not exists in database."
+                    self.log.error(msg)
+                    raise AssertionError(msg)
+
+            else:
+                msg = ("Instance {name!r} has been set to be as part of "
+                       "Asset: {asset!r}, but the current publish session "
+                       "is Asset: {task_asset!r}. "
+                       "Please check Context Manager."
+                       "".format(name=str(instance.data["name"]),
+                                 asset=str(asset),
+                                 task_asset=str(task_asset)))
+                self.log.error(msg)
+                raise AssertionError(msg)

--- a/plugins/houdini/create/create_arnold_standin.py
+++ b/plugins/houdini/create/create_arnold_standin.py
@@ -16,6 +16,11 @@ class CreateArnoldStandIn(houdini.Creator):
 
         self.data.update({"node_type": "arnold"})
 
+        # For user to confirm that this asset name is on demand, and
+        # able to publish even current Avalon session is not in this
+        # asset.
+        self.data["assetConfirmed"] = False
+
     def process(self):
         instance = super(CreateArnoldStandIn, self).process()
 

--- a/plugins/houdini/create/create_pointcache.py
+++ b/plugins/houdini/create/create_pointcache.py
@@ -17,6 +17,11 @@ class CreatePointCache(houdini.Creator):
 
         self.data.update({"node_type": "alembic"})
 
+        # For user to confirm that this asset name is on demand, and
+        # able to publish even current Avalon session is not in this
+        # asset.
+        self.data["assetConfirmed"] = False
+
     def process(self):
         instance = super(CreatePointCache, self).process()
 

--- a/plugins/houdini/create/create_vbd_cache.py
+++ b/plugins/houdini/create/create_vbd_cache.py
@@ -17,6 +17,11 @@ class CreateVDBCache(houdini.Creator):
         # Set node type to create for output
         self.data["node_type"] = "geometry"
 
+        # For user to confirm that this asset name is on demand, and
+        # able to publish even current Avalon session is not in this
+        # asset.
+        self.data["assetConfirmed"] = False
+
     def process(self):
         instance = super(CreateVDBCache, self).process()
 


### PR DESCRIPTION
### Motivation

In Reveries, one could not publish subset into asset which is not the one in current working context. For example, if current context's asset name is `A`, then one could not publish a subset that is assign to asset `B`.

This limitation is to avoid accidentally publishing to wrong asset when reusing pyblish instance in scene which was from other asset's context.

But in some senario, artist do like to publish into different asset on demand. To allow that, additional confirmation mechanism must be implemented.

### Implementation

The implementation of that confirmation mechanism is adding an attribute into pyblish instance object, called `assetConfirmed`. The default value of that attribute is `False`, so one must check that box to allow different asset name or the validation will failed.