### PR TITLE
Get matching result from ModelDiffer

### DIFF
--- a/reveries/tools/modeldiffer/app.py
+++ b/reveries/tools/modeldiffer/app.py
@@ -33,6 +33,7 @@ class Window(QtWidgets.QWidget):
 
         page = {
             "tab": QtWidgets.QTabWidget(),
+            "tables": list(),
         }
 
         page["tab"].addTab(QtWidgets.QWidget(), "+")
@@ -124,6 +125,8 @@ class Window(QtWidgets.QWidget):
         tab.setCurrentIndex(index)
         widget["top"]["line"].setText(name)
 
+        self.page["tables"].append(widget)
+
         # Connect
         with widget.pin("table.tabs") as table:
             with widget.pin("ctrl.tabs.select") as selectors:
@@ -140,6 +143,20 @@ class Window(QtWidgets.QWidget):
             with widget.pin("top") as top:
                 top["line"].textChanged.connect(
                     lambda text: tab.setTabText(index, text))
+
+    def table_to_dict(self):
+        """Return matched result as dict
+
+        The key of dict will be original(left) side item's `fullPath`, and the
+        value will be contrast(right) side item's `fullPath`.
+
+        """
+        tab = self.page["tab"]
+        index = tab.currentIndex()
+        widget = self.page["tables"][index - 1]
+
+        with widget.pin("table.tabs.comparer") as comparer:
+            return comparer.table_to_dict()
 
 
 def register_host_profiler(method):

--- a/reveries/tools/modeldiffer/models.py
+++ b/reveries/tools/modeldiffer/models.py
@@ -196,6 +196,18 @@ class ComparerModel(models.TreeModel):
             lib.icon("bullseye", color=SIDE_COLOR[SIDE_B]),
         ]
 
+    def to_dict(self):
+        result = dict()
+        items = self._root_item.children()
+        for item in items:
+            if item[SIDE_A_DATA] and item[SIDE_B_DATA]:
+                path_a = item[SIDE_A_DATA]["fullPath"]
+                path_b = item[SIDE_B_DATA]["fullPath"]
+
+                result[path_a] = path_b
+
+        return result
+
     def refresh_side(self, side, profile, host=False):
         profile = profile or dict()
 

--- a/reveries/tools/modeldiffer/views.py
+++ b/reveries/tools/modeldiffer/views.py
@@ -505,6 +505,9 @@ class ComparingTable(QtWidgets.QWidget):
         self.picked.emit(side, data)
         self.update()
 
+    def table_to_dict(self):
+        return self.data["model"].to_dict()
+
 
 class FocusComparing(QtWidgets.QWidget):
 


### PR DESCRIPTION
### Motivation

For fixing `AvalonID` miss match or other issues that involves comparing different models, one could directly reuse the model match result that ModelDiffer tool has done to do the fix.

### Implementation

Adding one function called `table_to_dict`, it will return the model name pair `dict` from current active tab.
