### PR TITLE
Re-implement remote publish version lock (pin)

### DIFF
--- a/plugins/filesys/publish/collect_instance_from_dump.py
+++ b/plugins/filesys/publish/collect_instance_from_dump.py
@@ -66,12 +66,14 @@ class CollectInstancesFromDump(pyblish.api.ContextPlugin):
 
                 previous_id = dump.pop("id")
                 child_ids = dump.pop("childInstances")
+                version_num = dump.pop("version")
 
                 instance = context.create_instance(dump["name"])
                 instance_by_id[previous_id] = instance
 
                 instance.data.update(dump)
 
+                instance.data["versionPin"] = version_num
                 instance.data["dumpId"] = previous_id
                 instance.data["childIds"] = child_ids
                 instance.data["childInstances"] = list()


### PR DESCRIPTION
### What's Changed

Intorduced a new instance data entry `"versionPin"`. This data entry is set from instance dump file which collected via the plugin in filesys publish, and will fixed the publish verison number per instance dump.