### PR TITLE
Fix setdress update not able to find container from cache and failed to work

### DIFF
--- a/plugins/maya/load/load_pointcache.py
+++ b/plugins/maya/load/load_pointcache.py
@@ -56,12 +56,12 @@ class PointCacheReferenceLoader(ReferenceLoader, avalon.api.Loader):
         self[:] = nodes
 
     def update(self, container, representation):
+        from reveries.maya.plugins import ReferenceLoader
         import maya.cmds as cmds
 
         uuid = cmds.ls(container["objectName"], uuid=True)
 
-        super(PointCacheReferenceLoader,
-              self).update(container, representation)
+        ReferenceLoader.update(self, container, representation)
 
         if representation["name"] == "Alembic":
             nodes = cmds.sets(cmds.ls(uuid), query=True, nodesOnly=True)

--- a/reveries/maya/hierarchy.py
+++ b/reveries/maya/hierarchy.py
@@ -426,6 +426,7 @@ def change_subset(container, namespace, root, data_new, data_old, force):
     from avalon.pipeline import get_representation_context
 
     container["_parent"] = data_new.pop("_parent", None)
+    container["_force_update"] = force
 
     is_repr_diff = (data_old["representation"] !=
                     data_new["representation"])


### PR DESCRIPTION
### Background
Set-dressing (Hierarchical) loader plugin will firstly look into a `.json` file to get a full list of subsets that it needs to load, and call other loaders to load those subsets.

And in order to place those subsets at the right position, that `.json` file also contains the matrix data and subset container id. The  set-dressing loader plugin will parse that id to find the subset which just being loaded into scene and apply the matrix data.

The process of finding container by id takes time and gets slower when you have a lot of subsets and growing in scene. So the container cache dict was intorduced.

```python
# like this
container_cache = {
    "container-id": container,
    ...
}
```

After the cache was applied into the loading loop, the speed was improved 10-40x, but a few days later it failed because the container id may be duplicated by artists, which cause the container in cache being overwriten and ends up re-positioning same subsets and leave a lot of stuff at the world space center.

To resolved this, the cache changed into like this:

```python
# like this
container_cache = {
    "container-id": [container, ...],
    ...
}
```

And pop up container from list once being matched to avoid re-applying data to same subset. It worked.

### The Bug & Fix

I did not test how new cache list will work when updating, and the bug was there.

In set-dressing updating, plugin may needs to find container twice for comparing current status with old and new data changes, so there's two function call which will access same container from cache.

And that's the problem, the container will be removed from cache once the match found.

The solution was simple, just collect all container ids from old and new data and query them in one call, and pass the resolved container list into next process.
