### PR TITLE
Change publish progress field in version data model

### DIFF
--- a/deadline/events/AvalonJobProgressDelete/AvalonJobProgressDelete.py
+++ b/deadline/events/AvalonJobProgressDelete/AvalonJobProgressDelete.py
@@ -87,7 +87,7 @@ class AvalonJobProgressDelete(Deadline.Events.DeadlineEventListener):
                                       "name": data["version"],
                                       "parent": subset["_id"]})
         avalon.io.update_many({"_id": version["_id"]},
-                              {"$unset": {"progress": "",
+                              {"$unset": {"data.progress": "",
                                           "data.deadlineJobId": ""}})
 
     def load_environment(self, job):

--- a/plugins/global/publish/integrate_avalon_database.py
+++ b/plugins/global/publish/integrate_avalon_database.py
@@ -54,10 +54,10 @@ class IntegrateAvalonDatabase(pyblish.api.InstancePlugin):
                     # Update version document "data.time"
                     filter_ = {"_id": existed_version["_id"]}
                     update = {"$set": {"data.time": context.data["time"]}}
-                    if "progress" in version:
+                    if "progress" in version["data"]:
                         # Update version document "progress.current"
-                        progress = version["progress"]["current"]
-                        update["$inc"] = {"progress.current": progress}
+                        progress = version["data"]["progress"]["current"]
+                        update["$inc"] = {"data.progress.current": progress}
                     else:
                         pass  # progress == -1, no progress update needed.
                     io.update_many(filter_, update)

--- a/plugins/global/publish/integrate_avalon_subset.py
+++ b/plugins/global/publish/integrate_avalon_subset.py
@@ -327,7 +327,7 @@ class IntegrateAvalonSubset(pyblish.api.InstancePlugin):
                 raise KeyError("Missing frame range data, this is a bug.")
 
             else:
-                version["progress"] = {
+                version["data"]["progress"] = {
                     "total": len(range(start, end + 1, step)),
                     "current": self.progress,
                 }


### PR DESCRIPTION
This is a patch for #195.

Consider "progress" as custom data so instead expose it in top level of
version document, move it into "data".